### PR TITLE
Windows

### DIFF
--- a/ament_tools/build_types/ament_cmake.py
+++ b/ament_tools/build_types/ament_cmake.py
@@ -113,7 +113,7 @@ class AmentCmakeBuildType(BuildType):
             if context.symlink_install:
                 cmake_args += ['-DAMENT_CMAKE_SYMLINK_INSTALL=1']
             if IS_WINDOWS:
-                cmake_args += ['-G', 'Visual Studio 12 2013 Win64']
+                cmake_args += ['-G', 'Visual Studio 14 2015 Win64']
             if CMAKE_EXECUTABLE is None:
                 raise VerbExecutionError("Could not find 'cmake' executable")
             yield BuildAction(prefix + [CMAKE_EXECUTABLE] + cmake_args)

--- a/ament_tools/build_types/ament_cmake.py
+++ b/ament_tools/build_types/ament_cmake.py
@@ -174,7 +174,6 @@ class AmentCmakeBuildType(BuildType):
             lines.append('if exist "{0}" call "{0}"\n'.format(local_setup))
         lines.append(
             'set "CMAKE_PREFIX_PATH=%CMAKE_PREFIX_PATH%;%AMENT_PREFIX_PATH%"')
-        lines += ['set PYTHONPATH']
         lines += ['%*']
         lines += ['if %ERRORLEVEL% NEQ 0 exit /b %ERRORLEVEL%']
         lines += ['if defined AMENT_TRACE_SETUP_FILES echo Leaving %~0']

--- a/ament_tools/build_types/ament_cmake.py
+++ b/ament_tools/build_types/ament_cmake.py
@@ -23,16 +23,21 @@ from ament_tools.context import ContextExtender
 
 from ament_tools.helper import extract_argument_group
 
+from ament_tools.build_types.cmake_common import CMAKE_EXECUTABLE
 from ament_tools.build_types.cmake_common import cmakecache_exists_at
 from ament_tools.build_types.cmake_common import has_make_target
-from ament_tools.build_types.cmake_common import makefile_exists_at
-from ament_tools.build_types.cmake_common import CMAKE_EXECUTABLE
 from ament_tools.build_types.cmake_common import MAKE_EXECUTABLE
+from ament_tools.build_types.cmake_common import makefile_exists_at
+from ament_tools.build_types.cmake_common import MSBUILD_EXECUTABLE
+from ament_tools.build_types.cmake_common import project_file_exists_at
+from ament_tools.build_types.cmake_common import solution_file_exists_at
 
 from ament_tools.build_types.common import get_cached_config
 from ament_tools.build_types.common import set_cached_config
 
 from ament_tools.verbs import VerbExecutionError
+
+IS_WINDOWS = os.name == 'nt'
 
 
 class AmentCmakeBuildType(BuildType):
@@ -107,14 +112,25 @@ class AmentCmakeBuildType(BuildType):
                 cmake_args += ["-DAMENT_ENABLE_TESTING=1"]
             if context.symlink_install:
                 cmake_args += ['-DAMENT_CMAKE_SYMLINK_INSTALL=1']
+            if IS_WINDOWS:
+                cmake_args += ['-G', 'Visual Studio 12 2013 Win64']
             if CMAKE_EXECUTABLE is None:
                 raise VerbExecutionError("Could not find 'cmake' executable")
             yield BuildAction(prefix + [CMAKE_EXECUTABLE] + cmake_args)
-        else:
+        elif not IS_WINDOWS:  # Nothing to do if False on Windows
             cmd = prefix + [MAKE_EXECUTABLE, 'cmake_check_build_system']
             yield BuildAction(cmd)
         # Now execute the build step
-        yield BuildAction(prefix + [MAKE_EXECUTABLE] + context.make_flags)
+        if IS_WINDOWS:
+            if MSBUILD_EXECUTABLE is None:
+                raise VerbExecutionError("Could not find 'msbuild' executable")
+            solution_file = solution_file_exists_at(
+                context.build_space, context.package_manifest.name)
+            yield BuildAction(prefix + [MSBUILD_EXECUTABLE, solution_file])
+        else:
+            if MAKE_EXECUTABLE is None:
+                raise VerbExecutionError("Could not find 'make' executable")
+            yield BuildAction(prefix + [MAKE_EXECUTABLE] + context.make_flags)
 
     def on_test(self, context):
         assert context.build_tests
@@ -130,10 +146,49 @@ class AmentCmakeBuildType(BuildType):
         # Figure out if there is a setup file to source
         prefix = self._get_command_prefix('install', context)
 
-        # Assumption: install target exists
-        yield BuildAction(prefix + [MAKE_EXECUTABLE, 'install'])
+        if IS_WINDOWS:
+            if MSBUILD_EXECUTABLE is None:
+                raise VerbExecutionError("Could not find 'msbuild' executable")
+            install_project_file = project_file_exists_at(
+                context.build_space, 'INSTALL')
+            yield BuildAction(prefix +
+                              [MSBUILD_EXECUTABLE, install_project_file])
+        else:
+            # Assumption: install target exists
+            if MAKE_EXECUTABLE is None:
+                raise VerbExecutionError("Could not find 'make' executable")
+            yield BuildAction(prefix + [MAKE_EXECUTABLE, 'install'])
 
     def _get_command_prefix(self, name, context):
+        if IS_WINDOWS:
+            return self._get_command_prefix_windows(name, context)
+        else:
+            return self._get_command_prefix_unix(name, context)
+
+    def _get_command_prefix_windows(self, name, context):
+        lines = []
+        lines.append('@echo off\n')
+        lines.append('if defined AMENT_TRACE_SETUP_FILES echo Inside %~0')
+        for path in context.build_dependencies:
+            local_setup = os.path.join(path, 'local_setup.bat')
+            lines.append('if exist "{0}" call "{0}"\n'.format(local_setup))
+        lines.append(
+            'set "CMAKE_PREFIX_PATH=%CMAKE_PREFIX_PATH%;%AMENT_PREFIX_PATH%"')
+        lines += ['set PYTHONPATH']
+        lines += ['%*']
+        lines += ['if %ERRORLEVEL% NEQ 0 exit /b %ERRORLEVEL%']
+        lines += ['if defined AMENT_TRACE_SETUP_FILES echo Leaving %~0']
+
+        generated_file = os.path.join(
+            context.build_space, '%s__%s.bat' %
+            (AmentCmakeBuildType.build_type, name))
+        with open(generated_file, 'w') as h:
+            for line in lines:
+                h.write('%s\n' % line)
+
+        return [generated_file]
+
+    def _get_command_prefix_unix(self, name, context):
         lines = []
         lines.append('#!/usr/bin/env sh\n')
         for path in context.build_dependencies:

--- a/ament_tools/build_types/ament_cmake.py
+++ b/ament_tools/build_types/ament_cmake.py
@@ -131,7 +131,7 @@ class AmentCmakeBuildType(BuildType):
             if CMAKE_EXECUTABLE is None:
                 raise VerbExecutionError("Could not find 'cmake' executable")
             yield BuildAction(prefix + [CMAKE_EXECUTABLE] + cmake_args)
-        elif not IS_WINDOWS:  # Nothing to do if False on Windows
+        elif not IS_WINDOWS:  # Check for reconfigure if available.
             cmd = prefix + [MAKE_EXECUTABLE, 'cmake_check_build_system']
             yield BuildAction(cmd)
         # Now execute the build step
@@ -188,9 +188,9 @@ class AmentCmakeBuildType(BuildType):
             lines.append('if exist "{0}" call "{0}"\n'.format(local_setup))
         lines.append(
             'set "CMAKE_PREFIX_PATH=%CMAKE_PREFIX_PATH%;%AMENT_PREFIX_PATH%"')
-        lines += ['%*']
-        lines += ['if %ERRORLEVEL% NEQ 0 exit /b %ERRORLEVEL%']
-        lines += ['if defined AMENT_TRACE_SETUP_FILES echo Leaving %~0']
+        lines.append('%*')
+        lines.append('if %ERRORLEVEL% NEQ 0 exit /b %ERRORLEVEL%')
+        lines.append('if defined AMENT_TRACE_SETUP_FILES echo Leaving %~0')
 
         generated_file = os.path.join(
             context.build_space, '%s__%s.bat' %

--- a/ament_tools/build_types/ament_cmake.py
+++ b/ament_tools/build_types/ament_cmake.py
@@ -25,6 +25,7 @@ from ament_tools.helper import extract_argument_group
 
 from ament_tools.build_types.cmake_common import CMAKE_EXECUTABLE
 from ament_tools.build_types.cmake_common import cmakecache_exists_at
+from ament_tools.build_types.cmake_common import get_visual_studio_version
 from ament_tools.build_types.cmake_common import has_make_target
 from ament_tools.build_types.cmake_common import MAKE_EXECUTABLE
 from ament_tools.build_types.cmake_common import makefile_exists_at
@@ -113,7 +114,20 @@ class AmentCmakeBuildType(BuildType):
             if context.symlink_install:
                 cmake_args += ['-DAMENT_CMAKE_SYMLINK_INSTALL=1']
             if IS_WINDOWS:
-                cmake_args += ['-G', 'Visual Studio 14 2015 Win64']
+                vsv = get_visual_studio_version()
+                if vsv is None:
+                    print("VisualStudioVersion is not set, please run within "
+                          "a VS2013 or VS2015 Command Prompt.")
+                    raise VerbExecutionError(
+                        "Could not determine Visual Studio Version.")
+                generator = None
+                if vsv == '12.0':
+                    generator = 'Visual Studio 12 2013 Win64'
+                elif vsv == '14.0':
+                    generator = 'Visual Studio 14 2015 Win64'
+                else:
+                    raise VerbExecutionError("Unknown VS version: " + vsv)
+                cmake_args += ['-G', generator]
             if CMAKE_EXECUTABLE is None:
                 raise VerbExecutionError("Could not find 'cmake' executable")
             yield BuildAction(prefix + [CMAKE_EXECUTABLE] + cmake_args)

--- a/ament_tools/build_types/ament_python.py
+++ b/ament_tools/build_types/ament_python.py
@@ -52,9 +52,10 @@ def is_appropriate_setup_extension(setup_file):
     if not IS_WINDOWS and stripped_filename.endswith('.bat'):
         # On non-Windows system, ignore .bat
         return False
-    if IS_WINDOWS and stripped_filename.endswith('.bat'):
+    if IS_WINDOWS and not stripped_filename.endswith('.bat'):
         # On Windows, ignore anything other than .bat
         return False
+    return True
 
 
 class AmentPythonBuildType(BuildType):

--- a/ament_tools/build_types/ament_python.py
+++ b/ament_tools/build_types/ament_python.py
@@ -86,10 +86,13 @@ class AmentPythonBuildType(BuildType):
                     os.path.join(
                         '$AMENT_CURRENT_PREFIX', pythonpath_environment_hook)
             elif name[:-3].endswith('.bat'):
-                variables['ENVIRONMENT_HOOKS_BAT'] = \
-                    'call:ament_append_value AMENT_ENVIRONMENT_HOOKS %s\n' % \
-                    os.path.join(
-                        '%AMENT_CURRENT_PREFIX%', pythonpath_environment_hook)
+                t = 'call:ament_append_value AMENT_ENVIRONMENT_HOOKS[%s] %s\n'
+                variables['ENVIRONMENT_HOOKS'] = t % (
+                    context.package_manifest.name,
+                    os.path.join('%AMENT_CURRENT_PREFIX%',
+                                 pythonpath_environment_hook)
+                )
+                variables['PROJECT_NAME'] = context.package_manifest.name
             content = configure_file(template_path, variables)
             destination_path = os.path.join(
                 context.build_space,

--- a/ament_tools/build_types/ament_python.py
+++ b/ament_tools/build_types/ament_python.py
@@ -231,11 +231,7 @@ class AmentPythonBuildType(BuildType):
             marker_dir = os.path.dirname(marker_file)
             if not os.path.exists(marker_dir):
                 os.makedirs(marker_dir)
-<<<<<<< HEAD
-            with open(marker_file, 'w'):
-=======
             with open(marker_file, 'w'):  # "touching" the file
->>>>>>> [windows] support ament cmake and python
                 pass
 
         # deploy environment hook for PYTHONPATH

--- a/ament_tools/build_types/cmake_common.py
+++ b/ament_tools/build_types/cmake_common.py
@@ -55,3 +55,8 @@ def project_file_exists_at(path, target):
     if not os.path.isfile(project_file):
         return None
     return project_file
+
+
+def get_visual_studio_version():
+    vsv = os.environ.get('VisualStudioVersion', None)
+    return vsv

--- a/ament_tools/build_types/cmake_common.py
+++ b/ament_tools/build_types/cmake_common.py
@@ -20,6 +20,7 @@ from osrf_pycommon.process_utils import which
 
 CMAKE_EXECUTABLE = which('cmake')
 MAKE_EXECUTABLE = which('make')
+MSBUILD_EXECUTABLE = which('msbuild')
 
 __target_re = re.compile(r'^([a-zA-Z0-9][a-zA-Z0-9_\.]*):')
 
@@ -34,9 +35,23 @@ def has_make_target(path, target):
 
 def cmakecache_exists_at(path):
     cmakecache = os.path.join(path, 'CMakeCache.txt')
-    return os.path.exists(cmakecache)
+    return os.path.isfile(cmakecache)
 
 
 def makefile_exists_at(path):
     makefile = os.path.join(path, 'Makefile')
-    return os.path.exists(makefile)
+    return os.path.isfile(makefile)
+
+
+def solution_file_exists_at(path, package_name):
+    solution_file = os.path.join(path, package_name + '.sln')
+    if not os.path.isfile(solution_file):
+        return None
+    return solution_file
+
+
+def project_file_exists_at(path, target):
+    project_file = os.path.join(path, target + '.vcxproj')
+    if not os.path.isfile(project_file):
+        return None
+    return project_file

--- a/ament_tools/verbs/build_pkg/cli.py
+++ b/ament_tools/verbs/build_pkg/cli.py
@@ -237,7 +237,8 @@ def run_command(build_action, context):
         " ".join(build_action.cmd), cwd))
     try:
         cmd = build_action.cmd
-        cmd = ' '.join([(shlex.quote(c) if c != '&&' else c) for c in cmd])
+        if os.name != 'nt':
+            cmd = ' '.join([(shlex.quote(c) if c != '&&' else c) for c in cmd])
         subprocess.check_call(cmd, shell=True, cwd=cwd)
     except subprocess.CalledProcessError as exc:
         print()


### PR DESCRIPTION
This pull request provides support for building `ament_cmake` and `ament_python` packages on Windows.
It provides `.bat` versions of `.sh` helper scripts like `<package_name>__build.sh` It also provides a new workflow for CMake which uses some custom options and calls out to `msbuild` rather than `make` for building and installing.

Connects to ros2/ros2#9