### PR TITLE
Fix nosetest in virtualenv

### DIFF
--- a/ament_tools/build_types/ament_python.py
+++ b/ament_tools/build_types/ament_python.py
@@ -23,8 +23,6 @@ import shutil
 import stat
 import sys
 
-from osrf_pycommon.process_utils import which
-
 from ament_package.templates import configure_file
 from ament_package.templates import get_environment_hook_template_path
 from ament_package.templates import get_package_level_template_names
@@ -34,9 +32,15 @@ from ament_package.templates import get_prefix_level_template_path
 from ament_tools.build_type import BuildAction
 from ament_tools.build_type import BuildType
 
-NOSETESTS_EXECUTABLE = which(
-    'nosetests3' if sys.version_info.major == 3 else 'nosetests')
 PYTHON_EXECUTABLE = sys.executable
+NOSETESTS_EXECUTABLE = None
+try:
+    import nose
+    # Use the -m module option for executing nose, to ensure we get the desired version.
+    # Looking for just nosetest or nosetest3 on the PATH was not reliable in virtualenvs.
+    NOSETESTS_EXECUTABLE = [PYTHON_EXECUTABLE, '-m', nose.__name__]
+except ImportError:
+    pass
 
 
 class AmentPythonBuildType(BuildType):
@@ -103,8 +107,7 @@ class AmentPythonBuildType(BuildType):
             'test', context, additional_lines=additional_lines)
         xunit_file = os.path.join(context.build_space, 'nosetests.xml')
         assert NOSETESTS_EXECUTABLE, 'Could not find nosetests'
-        cmd = [
-            NOSETESTS_EXECUTABLE,
+        cmd = NOSETESTS_EXECUTABLE + [
             '--nocapture',
             '--with-xunit', '--xunit-file=%s' % xunit_file,
             '--with-coverage', '--cover-erase',

--- a/ament_tools/build_types/ament_python.py
+++ b/ament_tools/build_types/ament_python.py
@@ -34,8 +34,6 @@ from ament_package.templates import get_prefix_level_template_path
 from ament_tools.build_type import BuildAction
 from ament_tools.build_type import BuildType
 
-from ament_tools.context import ContextExtender
-
 NOSETESTS_EXECUTABLE = which(
     'nosetests3' if sys.version_info.major == 3 else 'nosetests')
 PYTHON_EXECUTABLE = sys.executable
@@ -198,7 +196,7 @@ class AmentPythonBuildType(BuildType):
             marker_dir = os.path.dirname(marker_file)
             if not os.path.exists(marker_dir):
                 os.makedirs(marker_dir)
-            with open(marker_file, 'w') as f:
+            with open(marker_file, 'w'):
                 pass
 
         # deploy environment hook for PYTHONPATH

--- a/test/test_code_format.py
+++ b/test/test_code_format.py
@@ -4,7 +4,7 @@ import os
 
 def test_flake8():
     """Test source code for pyFlakes and PEP8 conformance"""
-    flake8style = flake8.engine.StyleGuide()
+    flake8style = flake8.engine.StyleGuide(max_line_length=100)
     report = flake8style.options.report
     report.start()
     this_dir = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
The batch CI job for OS X was not finding `nosetest3` because it was using Python3, but in a virtualenv.

This pull request changes the behavior to check for, and execute, nosetest with the current python executable, i.e. `sys.executable`.

This fixes the CI job: http://54.183.26.131:8080/job/ros2_batch_ci_osx/