### PR TITLE
short option for symlink-install

### DIFF
--- a/ament_tools/verbs/build_pkg/cli.py
+++ b/ament_tools/verbs/build_pkg/cli.py
@@ -181,6 +181,7 @@ def add_arguments(parser):
              'when testing after a successful install)',
     )
     parser.add_argument(
+        '-s',
         '--symlink-install',
         action='store_true',
         default=False,


### PR DESCRIPTION
i find myself typing --symlink-install a lot on ament invocations. Having a short option -s will help make it faster. The -s syntax is what we're all used to from the "ln" command, so hopefully it will be easy to remember.