### PR TITLE
add package types entry points

### DIFF
--- a/ament_tools/helper.py
+++ b/ament_tools/helper.py
@@ -21,8 +21,7 @@ import stat
 
 from multiprocessing import cpu_count
 
-from ament_package import package_exists_at
-from ament_package import PACKAGE_MANIFEST_FILENAME
+from ament_tools.package_types import package_exists_at
 
 
 def argparse_existing_dir(path):
@@ -37,8 +36,7 @@ def argparse_existing_package(path):
     path = argparse_existing_dir(path)
     if not package_exists_at(path):
         raise argparse.ArgumentTypeError(
-            "Path '%s' does not contain a '%s' file" %
-            (path, PACKAGE_MANIFEST_FILENAME))
+            "Path '%s' does not contain a package" % path)
     return path
 
 

--- a/ament_tools/package_types/__init__.py
+++ b/ament_tools/package_types/__init__.py
@@ -1,0 +1,69 @@
+# Copyright 2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections import Counter
+import pkg_resources
+
+AMENT_PACKAGE_TYPES_ENTRY_POINT = 'ament.package_types'
+
+
+def package_exists_at(path):
+    for package_type in get_package_types():
+        if package_type['package_exists_at'](path):
+            return True
+    return False
+
+
+def parse_package(path):
+    for package_type in get_package_types():
+        if package_type['package_exists_at'](path):
+            pkg = package_type['parse_package'](path)
+            return pkg
+    raise RuntimeError("Failed to parse package in '%s'" % path)
+
+
+def get_package_types():
+    entry_points = list(pkg_resources.iter_entry_points(group=AMENT_PACKAGE_TYPES_ENTRY_POINT))
+    if not entry_points:
+        raise RuntimeError('No package type entry points')
+    entry_points_data = [ep.load() for ep in entry_points]
+
+    # ensure unique names
+    counter = Counter()
+    counter.update([d['name'] for d in entry_points_data])
+    most_common = counter.most_common(1)[0]
+    if most_common[1] > 1:
+        raise RuntimeError("Multiple package types with the same name '%s'" % most_common[0])
+
+    # order topologically
+    ordered = []
+    by_name = {d['name']: [set(d['depends']), d] for d in entry_points_data}
+    while by_name:
+        for name in sorted(by_name.keys()):
+            depends = by_name[name][0]
+            # take first entry with no unsatisfied dependencies
+            if not depends:
+                data = by_name[name][1]
+                ordered.append(data)
+                del by_name[name]
+                # remove name from dependency list of other entries
+                for v in by_name.values():
+                    v[0].remove(name)
+                break
+        else:
+            raise RuntimeError(
+                'Failed to determine topological order of the following package types: ' +
+                (', '.join(sorted(by_name.keys()))))
+
+    return ordered

--- a/ament_tools/package_types/ament.py
+++ b/ament_tools/package_types/ament.py
@@ -1,0 +1,28 @@
+# Copyright 2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_package import package_exists_at
+from ament_package import PACKAGE_MANIFEST_FILENAME
+from ament_package import parse_package
+
+__all__ = ['entry_point_data']
+
+# meta information of the entry point
+entry_point_data = dict(
+    name='ament',
+    description="A package containing a '%s' manifest file." % PACKAGE_MANIFEST_FILENAME,
+    package_exists_at=package_exists_at,
+    parse_package=parse_package,
+    depends=[],
+)

--- a/ament_tools/package_types/cmake.py
+++ b/ament_tools/package_types/cmake.py
@@ -1,0 +1,110 @@
+# Copyright 2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import re
+
+from ament_package.dependency import Dependency
+from ament_package.export import Export
+from ament_package.package import Package
+
+__all__ = ['entry_point_data']
+
+
+def package_exists_at(path):
+    return os.path.exists(os.path.join(path, 'CMakeLists.txt'))
+
+
+def parse_package(path):
+    if not package_exists_at(path):
+        return None
+    cmakelists = os.path.join(path, 'CMakeLists.txt')
+    data = extract_data(cmakelists)
+    pkg = Package(filename=cmakelists, **data)
+    pkg.exports = [Export('build_type', content='cmake')]
+    return pkg
+
+
+def extract_data(cmakelists):
+    with open(cmakelists, 'r') as h:
+        content = h.read()
+    content = remove_cmake_comments(content)
+
+    data = {}
+    data['name'] = extract_project_name(content)
+    if not data['name']:
+        raise RuntimeError("Failed to extract project name from '%s'" % cmakelists)
+
+    build_depends = extract_build_dependencies(content)
+    data['build_depends'] = [Dependency(name) for name in build_depends]
+
+    return data
+
+
+def remove_cmake_comments(content):
+    lines = content.splitlines()
+    for index, line in enumerate(lines):
+        lines[index] = remove_cmake_comments_from_line(line)
+    return '\n'.join(lines)
+
+
+def remove_cmake_comments_from_line(line):
+    # match coments starting with # which are not within a string enclosed in double quotes
+    # strings:  vvvvvvvvv
+    # comments:           vvvvv
+    # other:                    vvvvvvvv
+    pattern = r'("[^"]*")|(#.*)|([^#"]*)'
+
+    modline = ''
+    for matches in re.findall(pattern, line):
+        modline += matches[0] + matches[2]
+    return modline
+
+
+def extract_project_name(content):
+    # extract project name
+    # keyword:          vvvvvvv
+    # optional whitespaces:    vvv  vvv                      vvv
+    # parenthesis:                vv                                    vv
+    # optional quotes:                 vvvv               vv
+    # project name:                        vvvvvvvvvvvvvvv
+    # optional languages:                                       vvvvvvvv
+    match = re.search(r'project\s*\(\s*("?)([a-zA-Z0-9_]+)\1(\s+[^\)]*)?\)', content)
+    if not match:
+        return None
+    return match.group(2)
+
+
+def extract_build_dependencies(content):
+    # extract found packages
+    # keyword:             vvvvvvvvvvvv
+    # optional whitespaces:            vvv  vvv                      vvv
+    # parenthesis:                        vv                                    vv
+    # optional quotes:                         vvvv               vv
+    # package name:                                vvvvvvvvvvvvvvv
+    # optional arguments:                                               vvvvvvvv
+    matches = re.findall(r'find_package\s*\(\s*("?)([a-zA-Z0-9_]+)\1(\s+[^\)]*)?\)', content)
+    return [m[1] for m in matches]
+
+
+# meta information of the entry point
+entry_point_data = dict(
+    name='cmake',
+    description="A package containing a 'CMakeLists.txt' file.",
+    package_exists_at=package_exists_at,
+    parse_package=parse_package,
+    # other package types must be checked before
+    # since they might also contain a CMakeLists.txt file
+    depends=['ament'],
+)

--- a/ament_tools/package_types/python.py
+++ b/ament_tools/package_types/python.py
@@ -1,0 +1,114 @@
+# Copyright 2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import distutils.core
+import re
+try:
+    import setuptools
+except ImportError:
+    pass
+
+from ament_package.dependency import Dependency
+from ament_package.export import Export
+from ament_package.package import Package
+
+__all__ = ['entry_point_data']
+
+
+def package_exists_at(path):
+    return os.path.exists(os.path.join(path, 'setup.py'))
+
+
+def parse_package(path):
+    if not package_exists_at(path):
+        return None
+    setuppy = os.path.join(path, 'setup.py')
+    data = extract_data(setuppy)
+    pkg = Package(filename=setuppy, **data)
+    pkg.exports = [Export('build_type', content='ament_python')]
+    return pkg
+
+
+def extract_data(setuppy):
+    # be sure you're in the directory containing
+    # setup.py so the sys.path manipulation works,
+    # so the import of __version__ works
+    old_cwd = os.getcwd()
+    os.chdir(os.path.dirname(os.path.abspath(setuppy)))
+    try:
+        data = {'name': 'unknown'}
+        fake_setup = create_mock_setup_function(data)
+        # patch setup() function of distutils and setuptools for the
+        # context of evaluating setup.py
+        try:
+            distutils_backup = distutils.core.setup
+            distutils.core.setup = fake_setup
+            try:
+                setuptools_backup = setuptools.setup
+                setuptools.setup = fake_setup
+            except NameError:
+                pass
+
+            with open('setup.py', 'r') as h:
+                exec(h.read())
+        finally:
+            distutils.core.setup = distutils_backup
+            try:
+                setuptools.setup = setuptools_backup
+            except NameError:
+                pass
+        return data
+
+    finally:
+        os.chdir(old_cwd)
+
+
+def create_mock_setup_function(data):
+    """
+    Create a setup function mock to capture its arguments.
+
+    It can replace either distutils.core.setup or setuptools.setup.
+
+    :param data: a dictionary which is updated with the captured arguments
+    :returns: a function to replace disutils.core.setup and setuptools.setup
+    """
+    def setup(*args, **kwargs):
+        if 'name' not in kwargs:
+            raise RuntimeError(
+                "setup() function invoked without the keyword argument 'name'")
+        data['name'] = kwargs['name']
+
+        if 'install_requires' in kwargs:
+            data['build_depends'] = []
+            for install_require in kwargs['install_requires']:
+                # split of version specifiers
+                name = re.split(r'<|>|<=|>=|==|!=', install_require)[0]
+                # map from Python package name to ROS package name convention
+                name = name.rstrip().replace('-', '_')
+                data['build_depends'].append(Dependency(name))
+
+    return setup
+
+
+# meta information of the entry point
+entry_point_data = dict(
+    name='python',
+    description="A package containing a 'setup.py' file.",
+    package_exists_at=package_exists_at,
+    parse_package=parse_package,
+    # other package types must be checked before
+    # since they might also contain a setup.py file
+    depends=['ament', 'cmake'],
+)

--- a/ament_tools/packages.py
+++ b/ament_tools/packages.py
@@ -18,8 +18,8 @@ Library to find packages in the filesystem.
 
 import os
 
-from ament_package import PACKAGE_MANIFEST_FILENAME
-from ament_package import parse_package
+from ament_tools.package_types import package_exists_at
+from ament_tools.package_types import parse_package
 
 
 def find_package_paths(basepath, exclude_paths=None):
@@ -42,7 +42,7 @@ def find_package_paths(basepath, exclude_paths=None):
         if 'AMENT_IGNORE' in filenames or real_dirpath in real_exclude_paths:
             del dirnames[:]
             continue
-        elif PACKAGE_MANIFEST_FILENAME in filenames:
+        elif package_exists_at(dirpath):
             paths.append(os.path.relpath(dirpath, basepath))
             del dirnames[:]
             continue

--- a/ament_tools/verbs/list_packages.py
+++ b/ament_tools/verbs/list_packages.py
@@ -14,9 +14,8 @@
 
 import os
 
-from ament_package import parse_package
-
 from ament_tools.helper import argparse_existing_dir
+from ament_tools.package_types import parse_package
 from ament_tools.packages import find_package_paths
 from ament_tools.packages import find_unique_packages
 from ament_tools.topological_order import topological_order_packages

--- a/ament_tools/verbs/package_name.py
+++ b/ament_tools/verbs/package_name.py
@@ -16,9 +16,8 @@ import argparse
 import os
 import sys
 
-from ament_package import parse_package
-
 from ament_tools.helper import argparse_existing_package
+from ament_tools.package_types import parse_package
 
 
 def prepare_arguments(parser):

--- a/ament_tools/verbs/package_version.py
+++ b/ament_tools/verbs/package_version.py
@@ -16,9 +16,8 @@ import argparse
 import os
 import sys
 
-from ament_package import parse_package
-
 from ament_tools.helper import argparse_existing_package
+from ament_tools.package_types import parse_package
 
 
 def prepare_arguments(parser):

--- a/ament_tools/verbs/uninstall_pkg/cli.py
+++ b/ament_tools/verbs/uninstall_pkg/cli.py
@@ -23,7 +23,7 @@ from ament_tools.helper import determine_path_argument
 from ament_tools.verbs.build_pkg.cli import __get_cached_package_manifest
 from ament_tools.verbs.build_pkg.cli import get_build_type
 from ament_tools.verbs.build_pkg.cli import handle_build_action
-from ament_tools.verbs.build_pkg.cli import validate_package_manifest_path
+from ament_tools.verbs.build_pkg.cli import validate_package_path
 
 
 def add_path_argument(parser):
@@ -99,7 +99,7 @@ def update_options(opts):
         cwd, opts.directory, opts.install_space, 'install')
 
     try:
-        opts.path = validate_package_manifest_path(opts.path)
+        validate_package_path(opts.path)
     except ValueError as exc:
         sys.exit("Error: {0}".format(exc))
 

--- a/scripts/ament.py
+++ b/scripts/ament.py
@@ -124,6 +124,25 @@ build_type_discovery.yield_supported_build_types = yield_supported_build_types
 build_type_discovery.get_class_for_build_type = get_class_for_build_type
 
 
+# override package type discovery relying on pkg_resources entry points
+from ament_tools.package_types.ament import entry_point_data as ament_entry_point_data  # noqa
+from ament_tools.package_types.cmake import entry_point_data as cmake_entry_point_data  # noqa
+from ament_tools.package_types.python import entry_point_data as python_entry_point_data  # noqa
+
+known_package_types = [
+    ament_entry_point_data,
+    cmake_entry_point_data,
+    python_entry_point_data,
+]
+
+
+def get_package_types():
+    return known_package_types
+
+from ament_tools import package_types  # noqa
+package_types.get_package_types = get_package_types
+
+
 from ament_tools.commands.ament import main  # noqa
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -46,5 +46,10 @@ and provides tooling to build these federated packages together.""",
             'ament_python = ament_tools.build_types.ament_python:AmentPythonBuildType',
             'cmake = ament_tools.build_types.cmake:CmakeBuildType',
         ],
+        'ament.package_types': [
+            'ament = ament_tools.package_types.ament:entry_point_data',
+            'cmake = ament_tools.package_types.cmake:entry_point_data',
+            'python = ament_tools.package_types.python:entry_point_data',
+        ],
     }
 )


### PR DESCRIPTION
This patch adds entry points for package types. In contrast to the *build type* which determines how a package is being processed the *package type* identifies a folder as a package and determines how the necessary meta information about a package is provided. The relevant information for processing packages with ament consist of the package `name` as well as the package `dependencies`.

Until now only `package.xml` files have been considered. With this change `ament` looks additionally for the following files:
* `CMakeLists.txt`
* `setup.py`

For `CMakeLists.txt` files the name is extracted from the `project(..)` call. The dependencies are collected from all `find_package(..)` calls. Both happens without considering any CMake variable evaluation.

For `setup.py` files the name is extracted from the keyword argument `name` to the `setup()` call. The dependencies are collected from the keyword argument `install_requires`.