### PR TITLE
Env hooks for plain cmake

### DIFF
--- a/ament_tools/build_types/ament_python.py
+++ b/ament_tools/build_types/ament_python.py
@@ -219,8 +219,7 @@ class AmentPythonBuildType(BuildType):
         template_path = get_environment_hook_template_path('path' + ext)
         deploy_file(
             context, os.path.dirname(template_path), os.path.basename(template_path),
-            dst_subfolder=os.path.join('share', context.package_manifest.name, 'environment'),
-            executable=True)
+            dst_subfolder=os.path.join('share', context.package_manifest.name, 'environment'))
 
         # deploy PYTHONPATH environment hook
         destination_file = 'pythonpath' + ('.sh' if not IS_WINDOWS else '.bat')
@@ -228,8 +227,7 @@ class AmentPythonBuildType(BuildType):
             context, context.build_space,
             os.path.join(
                 'share', context.package_manifest.name, 'environment',
-                destination_file),
-            executable=True)
+                destination_file))
 
         # deploy package-level setup files
         for name in get_package_level_template_names():
@@ -237,8 +235,7 @@ class AmentPythonBuildType(BuildType):
             deploy_file(
                 context, context.build_space,
                 os.path.join(
-                    'share', context.package_manifest.name, name[:-3]),
-                executable=True)
+                    'share', context.package_manifest.name, name[:-3]))
 
     def _add_install_layout(self, context, cmd):
         if 'dist-packages' in self._get_python_lib(context):

--- a/ament_tools/build_types/cmake.py
+++ b/ament_tools/build_types/cmake.py
@@ -241,8 +241,7 @@ class CmakeBuildType(BuildType):
         path_template_path = get_environment_hook_template_path('path' + ext)
         deploy_file(
             context, os.path.dirname(path_template_path), os.path.basename(path_template_path),
-            dst_subfolder=environment_hooks_path,
-            executable=True)
+            dst_subfolder=environment_hooks_path)
 
         environment_hooks = [path_template_path]
 
@@ -252,8 +251,7 @@ class CmakeBuildType(BuildType):
             deploy_file(
                 context,
                 os.path.dirname(library_template_path), os.path.basename(library_template_path),
-                dst_subfolder=environment_hooks_path,
-                executable=True)
+                dst_subfolder=environment_hooks_path)
             environment_hooks.append(library_template_path)
 
         # expand package-level setup files
@@ -266,7 +264,7 @@ class CmakeBuildType(BuildType):
                 context,
                 os.path.dirname(destination), os.path.basename(destination),
                 dst_subfolder=rel_destination_dir,
-                executable=True, skip_if_exists=True)
+                skip_if_exists=True)
 
     def _common_cmake_on_install(self, context):
         # Figure out if there is a setup file to source

--- a/ament_tools/build_types/cmake.py
+++ b/ament_tools/build_types/cmake.py
@@ -16,11 +16,14 @@
 
 import os
 
+from ament_package.templates import get_environment_hook_template_path
+
 from ament_tools.build_type import BuildAction
 from ament_tools.build_type import BuildType
 
 from ament_tools.context import ContextExtender
 
+from ament_tools.helper import deploy_file
 from ament_tools.helper import extract_argument_group
 
 from ament_tools.build_types.cmake_common import CMAKE_EXECUTABLE
@@ -34,6 +37,7 @@ from ament_tools.build_types.cmake_common import MSBUILD_EXECUTABLE
 from ament_tools.build_types.cmake_common import project_file_exists_at
 from ament_tools.build_types.cmake_common import solution_file_exists_at
 
+from ament_tools.build_types.common import expand_package_level_setup_files
 from ament_tools.build_types.common import get_cached_config
 from ament_tools.build_types.common import set_cached_config
 
@@ -215,6 +219,54 @@ class CmakeBuildType(BuildType):
         # Call cmake common on_install (defined in CmakeBuildType)
         for step in self._common_cmake_on_install(context):
             yield step
+
+        # Install files needed to extend the environment for build dependents to use this package
+        # create marker file
+        marker_file = os.path.join(
+            context.install_space,
+            'share', 'ament_index', 'resource_index', 'packages',
+            context.package_manifest.name)
+        if not os.path.exists(marker_file):
+            marker_dir = os.path.dirname(marker_file)
+            if not os.path.exists(marker_dir):
+                os.makedirs(marker_dir)
+            with open(marker_file, 'w'):  # "touching" the file
+                pass
+
+        environment_hooks_path = \
+            os.path.join('share', context.package_manifest.name, 'environment')
+
+        # deploy PATH environment hook
+        ext = '.sh' if not IS_WINDOWS else '.bat'
+        path_template_path = get_environment_hook_template_path('path' + ext)
+        deploy_file(
+            context, os.path.dirname(path_template_path), os.path.basename(path_template_path),
+            dst_subfolder=environment_hooks_path,
+            executable=True)
+
+        environment_hooks = [path_template_path]
+
+        # deploy library path environment hook
+        if not IS_WINDOWS:
+            library_template_path = get_environment_hook_template_path('library_path.sh')
+            deploy_file(
+                context,
+                os.path.dirname(library_template_path), os.path.basename(library_template_path),
+                dst_subfolder=environment_hooks_path,
+                executable=True)
+            environment_hooks.append(library_template_path)
+
+        # expand package-level setup files
+        destinations = expand_package_level_setup_files(
+            context, environment_hooks, environment_hooks_path)
+        for destination in destinations:
+            rel_destination_dir = \
+                os.path.dirname(os.path.relpath(destination, context.build_space))
+            deploy_file(
+                context,
+                os.path.dirname(destination), os.path.basename(destination),
+                dst_subfolder=rel_destination_dir,
+                executable=True, skip_if_exists=True)
 
     def _common_cmake_on_install(self, context):
         # Figure out if there is a setup file to source

--- a/ament_tools/build_types/common.py
+++ b/ament_tools/build_types/common.py
@@ -15,6 +15,65 @@
 import json
 import os
 
+from ament_package.templates import configure_file
+from ament_package.templates import get_package_level_template_names
+from ament_package.templates import get_package_level_template_path
+
+
+def expand_package_level_setup_files(context, environment_hooks, environment_hooks_path):
+    destinations = []
+
+    for name in get_package_level_template_names():
+        assert name.endswith('.in')
+
+        local_environment_hooks = []
+        if os.path.splitext(name[:-3])[1] in ['.sh', '.bat']:
+            local_environment_hooks.extend(environment_hooks)
+
+        # check if any data files are environment hooks (Python only)
+        for data_file in context.get('setup.py', {}).get('data_files', {}).values():
+            if not data_file.startswith(environment_hooks_path):
+                continue
+            # ignore data files with different extensions
+            if os.path.splitext(data_file)[1] != os.path.splitext(name[:-3])[1]:
+                continue
+            local_environment_hooks.append(data_file)
+
+        template_path = get_package_level_template_path(name)
+        variables = {'CMAKE_INSTALL_PREFIX': context.install_space}
+        if name[:-3].endswith('.bat'):
+            variables['PROJECT_NAME'] = context.package_manifest.name
+        if local_environment_hooks:
+            if name[:-3].endswith('.bat'):
+                t = 'call:ament_append_value AMENT_ENVIRONMENT_HOOKS[%s] "%s"\n'
+                variables['ENVIRONMENT_HOOKS'] = t % (
+                    context.package_manifest.name,
+                    ';'.join([
+                        os.path.join('%AMENT_CURRENT_PREFIX%', environment_hook)
+                        for environment_hook in local_environment_hooks
+                    ])
+                )
+            else:
+                variables['ENVIRONMENT_HOOKS'] = \
+                    'ament_append_value AMENT_ENVIRONMENT_HOOKS "%s"\n' % \
+                    ':'.join([
+                        os.path.join('$AMENT_CURRENT_PREFIX', environment_hook)
+                        for environment_hook in local_environment_hooks
+                    ])
+        content = configure_file(template_path, variables)
+        destination_path = os.path.join(
+            context.build_space,
+            'share', context.package_manifest.name,
+            name[:-3])
+        destination_dir = os.path.dirname(destination_path)
+        if not os.path.exists(destination_dir):
+            os.makedirs(destination_dir)
+        destinations.append(destination_path)
+        with open(destination_path, 'w') as h:
+            h.write(content)
+
+    return destinations
+
 
 def get_cached_config(build_space, name):
     path = os.path.join(build_space, '{name}.cache'.format(name=name))

--- a/ament_tools/helper.py
+++ b/ament_tools/helper.py
@@ -249,9 +249,9 @@ def deploy_file(
             # Finally if the content is not the same.
             if not filecmp.cmp(source_path, destination_path):
                 # We (probably) didn't install it and shouldn't overwrite it.
-                print("-- [ament] Skipping (would overwrite):", destination_path)
+                print('-- [ament] Skipping (would overwrite):', destination_path)
                 return
-    print("-- [ament] Deploying:", destination_path)
+    print('-- [ament] Deploying:', destination_path)
     destination_folder = os.path.dirname(destination_path)
     if not os.path.exists(destination_folder):
         os.makedirs(destination_folder)

--- a/ament_tools/helper.py
+++ b/ament_tools/helper.py
@@ -237,7 +237,10 @@ def deploy_file(
     destination_path = os.path.join(
         context.install_space, dst_subfolder, filename)
     # If the file exists and we should skip if we didn't install it.
-    if os.path.exists(destination_path) and skip_if_exists:
+    if (
+        (os.path.exists(destination_path) or os.path.islink(destination_path)) and
+        skip_if_exists
+    ):
         # If the dest is not a symlink or if it is but it doesn't point to our source.
         if (
             not os.path.islink(destination_path) or


### PR DESCRIPTION
So while testing `class_loader` I found that it's dependency `console_bridge`'s shared library could not be found at runtime (when running the tests). This was because `console_bridge` has no `local_setup.*` files and no environment hooks to add it's prefix to the `PATH` and `LD_LIBRARY_PATH`, etc.

I believe this problem is usually hidden because those prefixes are added to the appropriate `*PATH*`'s by other ament packages which install to the same place.

This pull request generates env hooks and setup files for plain cmake packages picked up by `ament_tools`.

I also added a message when ament is deploying files during installation and check to make sure when installing these extra files to the install prefix that we're not overwriting something that the original cmake package installed itself. You can test this by touching a file it would generate and install, e.g. `<prefix>/share/console_bridge/local_setup.sh`, and running the install of that package.

I'm pretty sure this is the right approach, but I'd welcome feedback on the idea.