### PR TITLE
generate coverage.xml file with nosetests

### DIFF
--- a/ament_tools/build_types/ament_python.py
+++ b/ament_tools/build_types/ament_python.py
@@ -109,6 +109,7 @@ class AmentPythonBuildType(BuildType):
             '--with-xunit', '--xunit-file=%s' % xunit_file,
             '--with-coverage', '--cover-erase',
             '--cover-tests', '--cover-branches',
+            '--cover-inclusive',
             '--cover-xml', '--cover-xml-file=%s' % coverage_xml_file,
         ]
         if LooseVersion(nose.__version__) >= LooseVersion('1.3.5'):

--- a/ament_tools/build_types/ament_python.py
+++ b/ament_tools/build_types/ament_python.py
@@ -103,11 +103,13 @@ class AmentPythonBuildType(BuildType):
         if not os.path.exists(os.path.dirname(xunit_file)):
             os.makedirs(os.path.dirname(xunit_file))
         assert NOSETESTS_EXECUTABLE, 'Could not find nosetests'
+        coverage_xml_file = os.path.join(context.build_space, 'coverage.xml')
         cmd = NOSETESTS_EXECUTABLE + [
             '--nocapture',
             '--with-xunit', '--xunit-file=%s' % xunit_file,
             '--with-coverage', '--cover-erase',
             '--cover-tests', '--cover-branches',
+            '--cover-xml', '--cover-xml-file=%s' % coverage_xml_file,
         ]
         if LooseVersion(nose.__version__) >= LooseVersion('1.3.5'):
             cmd += [


### PR DESCRIPTION
To be parsed by the Cobertura Jenkins plugin: https://wiki.jenkins-ci.org/display/JENKINS/Cobertura+Plugin

Without `--cover-inclusive`: http://ci.ros2.org/job/ros2_batch_ci_linux/517/cobertura/