### PR TITLE
use tuple for __all__ to fix pep257 warning

### DIFF
--- a/ament_tools/package_types/ament.py
+++ b/ament_tools/package_types/ament.py
@@ -16,7 +16,7 @@ from ament_package import package_exists_at
 from ament_package import PACKAGE_MANIFEST_FILENAME
 from ament_package import parse_package
 
-__all__ = ['entry_point_data']
+__all__ = ('entry_point_data')
 
 # meta information of the entry point
 entry_point_data = dict(

--- a/ament_tools/package_types/cmake.py
+++ b/ament_tools/package_types/cmake.py
@@ -19,7 +19,7 @@ from ament_package.dependency import Dependency
 from ament_package.export import Export
 from ament_package.package import Package
 
-__all__ = ['entry_point_data']
+__all__ = ('entry_point_data')
 
 
 def package_exists_at(path):

--- a/ament_tools/package_types/python.py
+++ b/ament_tools/package_types/python.py
@@ -21,7 +21,7 @@ from ament_package.package import Package
 
 from ament_tools.setup_arguments import get_setup_arguments
 
-__all__ = ['entry_point_data']
+__all__ = ('entry_point_data')
 
 
 def package_exists_at(path):

--- a/ament_tools/verbs/build/__init__.py
+++ b/ament_tools/verbs/build/__init__.py
@@ -16,7 +16,7 @@ from .cli import argument_preprocessor
 from .cli import main
 from .cli import prepare_arguments
 
-__all__ = ['entry_point_data']
+__all__ = ('entry_point_data')
 
 # meta information of the entry point
 entry_point_data = dict(

--- a/ament_tools/verbs/build_pkg/__init__.py
+++ b/ament_tools/verbs/build_pkg/__init__.py
@@ -16,7 +16,7 @@ from .cli import argument_preprocessor
 from .cli import main
 from .cli import prepare_arguments
 
-__all__ = ['entry_point_data']
+__all__ = ('entry_point_data')
 
 # meta information of the entry point
 entry_point_data = dict(

--- a/ament_tools/verbs/test/__init__.py
+++ b/ament_tools/verbs/test/__init__.py
@@ -17,7 +17,7 @@ from ament_tools.verbs.build.cli import argument_preprocessor
 from .cli import main
 from .cli import prepare_arguments
 
-__all__ = ['entry_point_data']
+__all__ = ('entry_point_data')
 
 # meta information of the entry point
 entry_point_data = dict(

--- a/ament_tools/verbs/test_pkg/__init__.py
+++ b/ament_tools/verbs/test_pkg/__init__.py
@@ -17,7 +17,7 @@ from ament_tools.verbs.build_pkg import prepare_arguments
 
 from .cli import main
 
-__all__ = ['entry_point_data']
+__all__ = ('entry_point_data')
 
 # meta information of the entry point
 entry_point_data = dict(

--- a/ament_tools/verbs/test_results/__init__.py
+++ b/ament_tools/verbs/test_results/__init__.py
@@ -15,7 +15,7 @@
 from .cli import main
 from .cli import prepare_arguments
 
-__all__ = ['entry_point_data']
+__all__ = ('entry_point_data')
 
 
 # meta information of the entry point

--- a/ament_tools/verbs/uninstall/__init__.py
+++ b/ament_tools/verbs/uninstall/__init__.py
@@ -15,7 +15,7 @@
 from .cli import main
 from .cli import prepare_arguments
 
-__all__ = ['entry_point_data']
+__all__ = ('entry_point_data')
 
 # meta information of the entry point
 entry_point_data = dict(

--- a/ament_tools/verbs/uninstall_pkg/__init__.py
+++ b/ament_tools/verbs/uninstall_pkg/__init__.py
@@ -15,7 +15,7 @@
 from .cli import main
 from .cli import prepare_arguments
 
-__all__ = ['entry_point_data']
+__all__ = ('entry_point_data')
 
 # meta information of the entry point
 entry_point_data = dict(


### PR DESCRIPTION
http://ci.ros2.org/job/ci_linux/694/consoleFull#console-section-126