### PR TITLE
generate xml of test summary

### DIFF
--- a/ament_tools/build_types/cmake.py
+++ b/ament_tools/build_types/cmake.py
@@ -185,7 +185,10 @@ class CmakeBuildType(BuildType):
                     raise VerbExecutionError("Could not find 'make' executable")
                 cmd = prefix + [MAKE_EXECUTABLE, 'test']
                 if 'ARGS' not in os.environ:
-                    args = ['-V']
+                    args = [
+                        '-V',
+                        # verbose output and generate xml of test summary
+                        '-D', 'ExperimentalTest', '--no-compress-output']
                 elif os.environ['ARGS']:
                     args = [os.environ['ARGS']]
                 else:


### PR DESCRIPTION
While this will "duplicate" the error reporting on Linux and OS X (the same way it is already on the Windows jobs) it helps to debug failing tests faster (e.g. if a test doesn't generate a result file the CTest log often contains more information).