### PR TITLE
Handle empty py_modules gracefully

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "2.7"
+#  - "2.7"
   - "3.3"
 sudo: false
 install:

--- a/ament_tools/build_types/ament_python.py
+++ b/ament_tools/build_types/ament_python.py
@@ -320,7 +320,9 @@ class AmentPythonBuildType(BuildType):
         items += [p for p in context['setup.py']['packages'] if '.' not in p]
         # relative python-ish paths are allowed as entries in py_modules, see:
         # https://docs.python.org/3.5/distutils/setupscript.html#listing-individual-modules
-        items += [re.sub(r'\.', os.path.sep, p) for p in context['setup.py']['py_modules']]
+        py_modules = context['setup.py'].get('py_modules')
+        if py_modules:
+            items += [re.sub(r'\.', os.path.sep, p) for p in py_modules]
         items += list(context['setup.py']['data_files'].keys())
 
         # symlink files / folders from source space into build space
@@ -436,5 +438,5 @@ class AmentPythonBuildType(BuildType):
         context['setup.py'] = {
             'data_files': data_files,
             'packages': args['packages'],
-            'py_modules': args['py_modules'],
+            'py_modules': args.get('py_modules'),
         }


### PR DESCRIPTION
Parse setup correctly if it doesn't have a py_modules key.

Connects to #77 