### PR TITLE
Fix error when calling build_pkg on ament_cmake package

### DIFF
--- a/ament_tools/build_types/ament_cmake.py
+++ b/ament_tools/build_types/ament_cmake.py
@@ -34,6 +34,7 @@ class AmentCmakeBuildType(CmakeBuildType):
     description = "ament package built with cmake"
 
     def prepare_arguments(self, parser):
+        super(AmentCmakeBuildType, self).prepare_arguments(parser)
         parser.add_argument(
             '--force-ament-cmake-configure',
             action='store_true',
@@ -49,10 +50,13 @@ class AmentCmakeBuildType(CmakeBuildType):
         # The ament CMake pass-through flag collects dashed options.
         # This requires special handling or argparse will complain about
         # unrecognized options.
-        args, cmake_args = extract_argument_group(args, '--ament-cmake-args')
-        extras = {
-            'ament_cmake_args': cmake_args,
-        }
+        args, extras = super(AmentCmakeBuildType, self).argument_preprocessor(args)
+        args, ament_cmake_args = extract_argument_group(args, '--ament-cmake-args')
+        extras.update(
+            {
+                'ament_cmake_args': ament_cmake_args,
+            }
+        )
         return args, extras
 
     def extend_context(self, options):

--- a/ament_tools/verbs/build/cli.py
+++ b/ament_tools/verbs/build/cli.py
@@ -115,6 +115,9 @@ def prepare_arguments(parser, args):
         help='List of packages to skip'
     )
 
+    # If multiple arguments with same option string are added, only keep the most recently-added
+    parser.conflict_handler = 'resolve'
+
     # Allow all available build_type's to provide additional arguments
     for build_type in yield_supported_build_types():
         build_type_impl = build_type.load()()


### PR DESCRIPTION
Whenever I try to use the build_pkg or test_pkg verbs on ament_cmake packages instead of build/test, I get the following error:
```
$ ament build_pkg .

Process package 'pendulum_msgs' with context:
--------------------------------------------------------------------------------
 source_space => /Users/deanna/ros2_ws/src-master/ros2/demos/pendulum_msgs
  build_space => /Users/deanna/ros2_ws/src-master/ros2/demos/pendulum_msgs/build/pendulum_msgs
install_space => /Users/deanna/ros2_ws/src-master/ros2/demos/pendulum_msgs/install
   make_flags => None
  build_tests => False
--------------------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/deanna/ros2_ws/src-master/ament/ament_tools/install/bin/ament", line 9, in <module>
    load_entry_point('ament-tools==0.0.0', 'console_scripts', 'ament')()
  File "/Users/deanna/ros2_ws/src-master/ament/ament_tools/install/lib/python3.5/site-packages/ament_tools/commands/ament.py", line 88, in main
    rc = args.main(args)
  File "/Users/deanna/ros2_ws/src-master/ament/ament_tools/install/lib/python3.5/site-packages/ament_tools/verbs/build_pkg/cli.py", line 270, in main
    context = get_context(opts)
  File "/Users/deanna/ros2_ws/src-master/ament/ament_tools/install/lib/python3.5/site-packages/ament_tools/verbs/build_pkg/cli.py", line 276, in get_context
    return create_context(opts)
  File "/Users/deanna/ros2_ws/src-master/ament/ament_tools/install/lib/python3.5/site-packages/ament_tools/verbs/build_pkg/cli.py", line 383, in create_context
    ce = build_type_impl.extend_context(opts)
  File "/Users/deanna/ros2_ws/src-master/ament/ament_tools/install/lib/python3.5/site-packages/ament_tools/build_types/ament_cmake.py", line 59, in extend_context
    ce = super(AmentCmakeBuildType, self).extend_context(options)
  File "/Users/deanna/ros2_ws/src-master/ament/ament_tools/install/lib/python3.5/site-packages/ament_tools/build_types/cmake.py", line 88, in extend_context
    force_cmake_configure = options.force_cmake_configure
AttributeError: 'Namespace' object has no attribute 'force_cmake_configure'
```

I think an appropriate fix is to call super().prepare_arguments in AmentCmakeBuildType, as was done in 
https://github.com/ament/ament_tools/commit/a682b3d01cce1eb5691937a9df3bf90f59a1b2cf

However, since in the 'build' verb prepare_arguments [is called for both](https://github.com/ament/ament_tools/blob/release-alpha4/ament_tools/verbs/build/cli.py#L123) AmentCmakeBuildType and CmakeBuildType, it's also necessary to use the 'resolve' conflict handler on the (sub)parser so it doesn't give an error when the arguments are added a second time.

I've just added the use of the resolve conflict handler for that specific parser, but if you think it's appropriate more globally, then I think this is where it would go: https://github.com/osrf/osrf_pycommon/blob/release-alpha3/osrf_pycommon/cli_utils/verb_pattern.py#L98