### PR TITLE
Fix autocomplete for build_pkg/test_pkg options

### DIFF
--- a/completion/ament-completion.bash
+++ b/completion/ament-completion.bash
@@ -28,7 +28,7 @@ _ament()
     COMPREPLY=( $( compgen -P "-DCMAKE_BUILD_TYPE=" -W "Debug MinSizeRel None Release RelWithDebInfo" -- "${cur:19}" ) )
   else
     if [[ "${COMP_WORDS[@]}" == *" build_pkg"* || "${COMP_WORDS[@]}" == *" test_pkg"* ]] ; then
-      COMPREPLY=($(compgen -W "--build-space --build-tests --install-space --make-flags --skip-build --skip-install --symlink-install" -- ${cur}))
+      COMPREPLY=($(compgen -W "--ament-cmake-args --build-space --build-tests --cmake-args --ctest-args --force-ament-cmake-configure --force-cmake-configure --install-space --make-flags --skip-build --skip-install --symlink-install" -- ${cur}))
     elif [[ "${COMP_WORDS[@]}" == *" build"* || "${COMP_WORDS[@]}" == *" test"* ]] ; then
       if [[ "--start-with" == *${prev}* && ${cur} != -* ]] ; then
         COMPREPLY=($(compgen -W "$(ament list_packages --names-only)" -- ${cur}))

--- a/completion/ament-completion.bash
+++ b/completion/ament-completion.bash
@@ -27,7 +27,9 @@ _ament()
     # autocomplete CMake argument CMAKE_BUILD_TYPE with its options
     COMPREPLY=( $( compgen -P "-DCMAKE_BUILD_TYPE=" -W "Debug MinSizeRel None Release RelWithDebInfo" -- "${cur:19}" ) )
   else
-    if [[ "${COMP_WORDS[@]}" == *" build"* || "${COMP_WORDS[@]}" == *" test"* ]] ; then
+    if [[ "${COMP_WORDS[@]}" == *" build_pkg"* || "${COMP_WORDS[@]}" == *" test_pkg"* ]] ; then
+      COMPREPLY=($(compgen -W "--build-space --build-tests --install-space --make-flags --skip-build --skip-install --symlink-install" -- ${cur}))
+    elif [[ "${COMP_WORDS[@]}" == *" build"* || "${COMP_WORDS[@]}" == *" test"* ]] ; then
       if [[ "--start-with" == *${prev}* && ${cur} != -* ]] ; then
         COMPREPLY=($(compgen -W "$(ament list_packages --names-only)" -- ${cur}))
       elif [[ "--end-with" == *${prev}* && ${cur} != -* ]] ; then


### PR DESCRIPTION
Completion for build_pkg verb was showing the options for build.

Before:
```
$ ament build_pkg -
--ament-cmake-args             --end-with                     --isolated                     --skip-install
--build-space                  --force-ament-cmake-configure  --make-flags                   --start-with
--build-tests                  --force-cmake-configure        --only-package                 --symlink-install
--cmake-args                   --install-space                --skip-build                   -C
```

After:
```
$ ament build_pkg --
--build-space      --build-tests      --install-space    --make-flags       --skip-build       --skip-install     --symlink-install
```