### PR TITLE
ensure exec dependencies are sourced when testing

### DIFF
--- a/ament_tools/verbs/build/cli.py
+++ b/ament_tools/verbs/build/cli.py
@@ -225,6 +225,7 @@ def iterate_packages(opts, packages, per_package_callback):
     opts.skip_packages = opts.skip_packages or []
     install_space_base = opts.install_space
     package_dict = dict([(path, package) for path, package, _ in packages])
+    workspace_package_names = [pkg.name for pkg in package_dict.values()]
     for (path, package, depends) in packages:
         if package.name == opts.start_with:
             start_with_found = True
@@ -251,6 +252,19 @@ def iterate_packages(opts, packages, per_package_callback):
                     install_space = os.path.join(install_space, depend)
                 package_share = os.path.join(install_space, 'share', depend)
                 opts.build_dependencies.append(package_share)
+
+            # get the package share folder for each exec depend of the package
+            opts.exec_dependency_paths_in_workspace = []
+            for dep_object in package.exec_depends:
+                dep_name = dep_object.name
+                if dep_name not in workspace_package_names:
+                    # do not add to this list if the dependency is not in the workspace
+                    continue
+                install_space = install_space_base
+                if opts.isolated:
+                    install_space = os.path.join(install_space, dep_name)
+                package_share = os.path.join(install_space, 'share', dep_name)
+                opts.exec_dependency_paths_in_workspace.append(package_share)
 
             rc = per_package_callback(opts)
             if rc:

--- a/ament_tools/verbs/build_pkg/cli.py
+++ b/ament_tools/verbs/build_pkg/cli.py
@@ -353,6 +353,8 @@ def create_context(opts):
     context.install = True
     context.build_dependencies = opts.build_dependencies \
         if 'build_dependencies' in opts else []
+    context.exec_dependency_paths_in_workspace = opts.exec_dependency_paths_in_workspace \
+        if 'exec_dependency_paths_in_workspace' in opts else []
     context.symlink_install = opts.symlink_install
     context.make_flags = opts.make_flags
     context.dry_run = False


### PR DESCRIPTION
This came up when I removed the unnecessary `test_depend` on `ament_index_python` after a discussion here: https://github.com/ros2/rclpy/pull/5#discussion_r57928777

I believe this is the correct course of action for now. Basically every step of the build process (build, test, install, uninstall) can produce a "prefix" file which is a shell script which is placed before the command being run (make, ctest, msbuild, whatever) that can source setup files from other packages. Right now, all of these files will try to source the package specific local setup file for each package which comes before it in topological order (basically that packages direct build/test/buildtool dependencies and the recursive run dependencies of those direct dependencies). Because of this, dependencies which are listed as an exec depend only (not also a build/buildtool/exec depend) would not be sourced before running tests because it would not make into the test prefix file (usually named `cmake__test.{sh|bat}`).

This pull request extends what was already being added by including the exec depends of the package being tested. Some of these dependencies may not be packages in the repository, but all source lines are guarded by an "if-exists-then-source" type of logic, so it's ok.

Connects to ros2/rclpy#5