### PR TITLE
add --parallel option

### DIFF
--- a/ament_tools/verbs/build_pkg/cli.py
+++ b/ament_tools/verbs/build_pkg/cli.py
@@ -248,8 +248,8 @@ def run_command(build_action, context):
         cmd_msg = exc.cmd
         if isinstance(cmd_msg, list):
             cmd_msg = ' '.join(cmd_msg)
-        sys.exit("<== Command '{0}' failed with exit code '{1}'"
-                 .format(cmd_msg, exc.returncode))
+        sys.exit("<== Command '{0}' failed in '{1}' with exit code '{2}'"
+                 .format(cmd_msg, cwd, exc.returncode))
 
 
 def handle_build_action(build_action_ret, context):

--- a/completion/ament-completion.bash
+++ b/completion/ament-completion.bash
@@ -39,7 +39,7 @@ _ament()
       elif [[ "--cmake-args" == *${prev}* && ${cur} != -* ]] ; then
         COMPREPLY=($(compgen -W "-DCMAKE_BUILD_TYPE=" -- ${cur}))
       else
-        COMPREPLY=($(compgen -W "--ament-cmake-args --build-space --build-tests -C --cmake-args --end-with --force-ament-cmake-configure --force-cmake-configure --make-flags --install-space --isolated --only-package --skip-build --skip-install --start-with --symlink-install" -- ${cur}))
+        COMPREPLY=($(compgen -W "--ament-cmake-args --build-space --build-tests -C --cmake-args --end-with --force-ament-cmake-configure --force-cmake-configure --make-flags --install-space --isolated --only-package --parallel --skip-build --skip-install --start-with --symlink-install" -- ${cur}))
       fi
     elif [[ "${COMP_WORDS[@]}" == *" list_packages"* ]] ; then
       if [[ "--depends-on" == *${prev}* && ${cur} != -* ]] ; then


### PR DESCRIPTION
While the interleaved output is not pretty to read the option achieves its goal to build packages in parallel and therefore speed up the build. The option is available for the `build` as well as the `test` verb. `--end` is still based on the sequential order and doesn't ignore packages which are before in the order but not recursive dependencies of the end package.

* http://ci.ros2.org/job/ci_linux/1604/
* http://ci.ros2.org/job/ci_osx/1217/
* http://ci.ros2.org/job/ci_windows/1588/

Please review.