### PR TITLE
Add info about return code

### DIFF
--- a/ament_tools/verbs/build_pkg/cli.py
+++ b/ament_tools/verbs/build_pkg/cli.py
@@ -252,8 +252,10 @@ def run_command(build_action, context):
         cmd_msg = exc.cmd
         if isinstance(cmd_msg, list):
             cmd_msg = ' '.join(cmd_msg)
-        sys.exit("<== Command '{0}' failed in '{1}' with exit code '{2}'"
-                 .format(cmd_msg, cwd, exc.returncode))
+        msg = "<== Command '{0}' failed in '{1}' with exit code '{2}'" \
+            .format(cmd_msg, cwd, exc.returncode)
+        print(msg, file=sys.stderr)
+        sys.exit(msg)
 
 
 def handle_build_action(build_action_ret, context):

--- a/ament_tools/verbs/test/cli.py
+++ b/ament_tools/verbs/test/cli.py
@@ -14,6 +14,8 @@
 
 from __future__ import print_function
 
+import sys
+
 from ament_tools.verbs.build import prepare_arguments \
     as build_prepare_arguments
 from ament_tools.verbs.build.cli import main as build_main
@@ -49,6 +51,9 @@ def main(opts):
     def test_pkg_main_wrapper(opts):
         rc = test_pkg_main(opts)
         if rc:
+            print(
+                "'test_pkg' for package '%s' failed: %s" % (opts.path, rc),
+                file=sys.stderr)
             rc_storage['rc'] = rc
             if opts.abort_on_test_error:
                 return rc

--- a/ament_tools/verbs/test_pkg/cli.py
+++ b/ament_tools/verbs/test_pkg/cli.py
@@ -84,7 +84,11 @@ def main(opts):
                 print("+++ Testing '%s' again (retry #%d of %d)" %
                       (pkg_name, context.test_iteration, opts.retest_until_pass))
                 continue
-            return 1
+            # there is no way to distinguish why the test returned non zero
+            # the test invocation itself could have failed:
+            # return e.code
+            # but it could have also run successful and only failed some tests:
+            return
         # check if tests should be rerun
         if opts.retest_until_fail > context.test_iteration:
             context.test_iteration += 1


### PR DESCRIPTION
The first commit adds more information.

The second commit changes the return value in case the test commands fail. Until recently the Jenkins jobs ignored the return code but that was changed when I found out that the coverage job was silently failing (ros2/ci#1). Since there is no way to determine why the rc is non-zero (could be "just" failing tests or the `ctest` invocation itself failing due to unrelated problems) we have to settle for one choice. Since we do have repeatedly failing tests from time to time we want the job to not fail in these cases but be marked unstable. As a trade off if for some reason our test invocations fails badly independent from actual tests we wouldn't notice that until looking closely into the console output...

Now passing again: http://ci.ros2.org/job/ci_windows/1713/