### PR TITLE
allow multiple package names for --only-packages

### DIFF
--- a/completion/ament-completion.bash
+++ b/completion/ament-completion.bash
@@ -34,12 +34,12 @@ _ament()
         COMPREPLY=($(compgen -W "$(ament list_packages --names-only)" -- ${cur}))
       elif [[ "--end-with" == *${prev}* && ${cur} != -* ]] ; then
         COMPREPLY=($(compgen -W "$(ament list_packages --names-only)" -- ${cur}))
-      elif [[ "--only-package" == *${prev}* && ${cur} != -* ]] ; then
+      elif [[ "--only-packages" == *${prev}* && ${cur} != -* ]] ; then
         COMPREPLY=($(compgen -W "$(ament list_packages --names-only)" -- ${cur}))
       elif [[ "--cmake-args" == *${prev}* && ${cur} != -* ]] ; then
         COMPREPLY=($(compgen -W "-DCMAKE_BUILD_TYPE=" -- ${cur}))
       else
-        COMPREPLY=($(compgen -W "--ament-cmake-args --build-space --build-tests -C --cmake-args --end-with --force-ament-cmake-configure --force-cmake-configure --make-flags --install-space --isolated --only-package --parallel --skip-build --skip-install --start-with --symlink-install" -- ${cur}))
+        COMPREPLY=($(compgen -W "--ament-cmake-args --build-space --build-tests -C --cmake-args --end-with --force-ament-cmake-configure --force-cmake-configure --make-flags --install-space --isolated --only-packages --parallel --skip-build --skip-install --start-with --symlink-install" -- ${cur}))
       fi
     elif [[ "${COMP_WORDS[@]}" == *" list_packages"* ]] ; then
       if [[ "--depends-on" == *${prev}* && ${cur} != -* ]] ; then


### PR DESCRIPTION
* Extract checking the passed arguments for sane values and combinations.
* Enables multiple package names to be passed to `--only-packages`.
* Consolidates all the criteria which packages should be processed in a single attribute (`start_with`, `end_with`, `only_packages` are merged into `skip_packages`).
* Printing the topological order as well as the actual iteration over the packages then uses the consolidated result without the need to reimplement the logic.