### PR TITLE
make not ignored pkgs more visible

### DIFF
--- a/ament_tools/verbs/build/cli.py
+++ b/ament_tools/verbs/build/cli.py
@@ -236,7 +236,7 @@ def print_topological_order(opts, package_names):
     print('# Topological order')
     for pkg_name in package_names:
         if pkg_name in opts.skip_packages:
-            print(' - (%s)' % pkg_name)
+            print(' - ( %s )' % pkg_name)
         else:
             print(' - %s' % pkg_name)
 


### PR DESCRIPTION
This minor cosmetic change makes is easier to visually search through the list of packages and find the ones which are (not) ignored.