### PR TITLE
Ament set environm var when running.

### DIFF
--- a/ament_tools/commands/ament.py
+++ b/ament_tools/commands/ament.py
@@ -14,6 +14,7 @@
 
 import argparse
 import sys
+import os
 
 from ament_tools.verbs import VerbExecutionError
 
@@ -29,6 +30,8 @@ VERBS_ENTRY_POINT = '{0}.verbs'.format(COMMAND_NAME)
 def main(sysargs=None):
     # Assign sysargs if not set
     sysargs = sys.argv[1:] if sysargs is None else sysargs
+
+    os.environ['AMENT_TOOLS'] = '1'
 
     # Create a top level parser
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
See issue https://github.com/ament/ament_cmake/issues/56

When ament is running, the env var `BUILT_WITH_AMENT_BUILD` is set to `true`, so that cmake or other builder can check whether they were invokated by ament or not.
This is useful for example when migrating from a different build system (catkin or plain cmake) to ament because the package is aware of what's going on and can do adjustments to cope with different situations. In my case the installation folder for config files changes; in this way I can do it correctly.

The env var is visible only to threads/processes started by ament itself. When ament terminates, the shell it reeturns to does not have the env var of course.