### PR TITLE
Package name as warnings return in package obj

### DIFF
--- a/ament_tools/package_types/ament.py
+++ b/ament_tools/package_types/ament.py
@@ -23,6 +23,7 @@ entry_point_data = dict(
     name='ament',
     description="A package containing a '%s' manifest file." % PACKAGE_MANIFEST_FILENAME,
     package_exists_at=package_exists_at,
-    parse_package=parse_package,
+    parse_package=lambda path:
+      parse_package(path, package_name_warning_not_error=True),
     depends=[],
 )

--- a/ament_tools/package_types/ament.py
+++ b/ament_tools/package_types/ament.py
@@ -24,6 +24,6 @@ entry_point_data = dict(
     description="A package containing a '%s' manifest file." % PACKAGE_MANIFEST_FILENAME,
     package_exists_at=package_exists_at,
     parse_package=lambda path:
-      parse_package(path, package_name_warning_not_error=True),
+        parse_package(path, package_name_warning_not_error=True),
     depends=[],
 )

--- a/ament_tools/verbs/build/cli.py
+++ b/ament_tools/verbs/build/cli.py
@@ -169,7 +169,23 @@ def main(opts, per_package_main=build_pkg_main):
               file=sys.stderr)
         return 0
 
-    return iterate_packages(opts, packages, per_package_main)
+    try:
+        return iterate_packages(opts, packages, per_package_main)
+    finally:
+        # On exit, let the user know about any package.xml parsing warnings.
+        warning_strings = []
+        for path, package, _ in packages:
+            for warning in getattr(package, 'parsing_warnings', []):
+                warning_strings.append(
+                    "  - Warning from parsing '%s' for package '%s': %s"
+                    % (os.path.abspath(package.filename), package.name, warning)
+                )
+        if warning_strings:
+            print("\n/!\\ Notice /!\\", file=sys.stderr)
+            print("There were some warnings while parsing package manifests:", file=sys.stderr)
+            for warning in warning_strings:
+                print(warning, file=sys.stderr)
+            print("", file=sys.stderr)
 
 
 def check_opts(opts, package_names):


### PR DESCRIPTION
This uses the new features in ament/ament_package#49 to make package name violations warnings rather than errors, and then report any warnings on exit. A warning looks like this in action:

```
-- Configuring incomplete, errors occurred!
See also "/Users/william/ros2_ws/build_isolated/cartographer_ros_msgs/CMakeFiles/CMakeOutput.log".

<== Command '. /Users/william/ros2_ws/build_isolated/cartographer_ros_msgs/cmake__build.sh && /usr/local/bin/cmake /Users/william/ros2_ws/src/ros2/cartographer_ros/cartographer_ros_msgs -DBUILD_TESTING=1 -DAMENT_CMAKE_SYMLINK_INSTALL=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=/Users/william/ros2_ws/install_isolated/cartographer_ros_msgs' failed in '/Users/william/ros2_ws/build_isolated/cartographer_ros_msgs' with exit code '1'

/!\ Notice /!\
There were some warnings while parsing package manifests:
  - Warning from parsing '/Users/william/ros2_ws/src/vendor/ceres-solver/package.xml' for package 'ceres-solver': Package name 'ceres-solver' does not follow naming conventions

<== Command '. /Users/william/ros2_ws/build_isolated/cartographer_ros_msgs/cmake__build.sh && /usr/local/bin/cmake /Users/william/ros2_ws/src/ros2/cartographer_ros/cartographer_ros_msgs -DBUILD_TESTING=1 -DAMENT_CMAKE_SYMLINK_INSTALL=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=/Users/william/ros2_ws/install_isolated/cartographer_ros_msgs' failed in '/Users/william/ros2_ws/build_isolated/cartographer_ros_msgs' with exit code '1'
```

We could consider even ignoring this kind of warning for CMake packages which have their name extracted from the `project()` call in the future.

Connects to ament/ament_package#49