### PR TITLE
Added support for ninja build system

### DIFF
--- a/ament_tools/build_types/ament_cmake.py
+++ b/ament_tools/build_types/ament_cmake.py
@@ -62,7 +62,6 @@ class AmentCmakeBuildType(CmakeBuildType):
             force_ament_cmake_configure = True
         ce.add('force_ament_cmake_configure', force_ament_cmake_configure)
         ce.add('ament_cmake_args', options.ament_cmake_args)
-
         return ce
 
     def on_build(self, context):

--- a/ament_tools/build_types/ament_cmake.py
+++ b/ament_tools/build_types/ament_cmake.py
@@ -32,7 +32,7 @@ IS_WINDOWS = os.name == 'nt'
 class AmentCmakeBuildType(CmakeBuildType):
     build_type = 'ament_cmake'
     description = "ament package built with cmake"
-    
+
     def prepare_arguments(self, parser):
         parser.add_argument(
             '--force-ament-cmake-configure',
@@ -62,7 +62,7 @@ class AmentCmakeBuildType(CmakeBuildType):
             force_ament_cmake_configure = True
         ce.add('force_ament_cmake_configure', force_ament_cmake_configure)
         ce.add('ament_cmake_args', options.ament_cmake_args)
-        
+
         return ce
 
     def on_build(self, context):

--- a/ament_tools/build_types/ament_cmake.py
+++ b/ament_tools/build_types/ament_cmake.py
@@ -70,7 +70,7 @@ class AmentCmakeBuildType(CmakeBuildType):
         should_run_configure = False
         if context.force_ament_cmake_configure or context.force_cmake_configure:
             should_run_configure = True
-        elif context.ninja_build and not ninjabuild_exists_at(context.build_space):
+        elif context.use_ninja and not ninjabuild_exists_at(context.build_space):
             should_run_configure = True
         elif not makefile_exists_at(context.build_space) or \
                 not cmakecache_exists_at(context.build_space):
@@ -102,12 +102,9 @@ class AmentCmakeBuildType(CmakeBuildType):
                 extra_cmake_args += ['-DAMENT_CMAKE_SYMLINK_INSTALL=1']
             extra_cmake_args += context.cmake_args
             extra_cmake_args += context.ament_cmake_args
-        if context.ninja_build:
+        if context.use_ninja:
             extra_cmake_args += ['-G']
             extra_cmake_args += ['Ninja']
-            extra_cmake_args += ["-DCMAKE_MAKE_PROGRAM=/usr/bin/ninja"]
-        
-        self.warn(extra_cmake_args)   
         # Yield the cmake common on_build (defined in CmakeBuildType)
         for step in self._common_cmake_on_build(
             should_run_configure, context, prefix, extra_cmake_args

--- a/ament_tools/build_types/ament_cmake.py
+++ b/ament_tools/build_types/ament_cmake.py
@@ -102,8 +102,7 @@ class AmentCmakeBuildType(CmakeBuildType):
             extra_cmake_args += context.cmake_args
             extra_cmake_args += context.ament_cmake_args
         if context.use_ninja:
-            extra_cmake_args += ['-G']
-            extra_cmake_args += ['Ninja']
+            extra_cmake_args += ['-G', 'Ninja']
         # Yield the cmake common on_build (defined in CmakeBuildType)
         for step in self._common_cmake_on_build(
             should_run_configure, context, prefix, extra_cmake_args

--- a/ament_tools/build_types/cmake.py
+++ b/ament_tools/build_types/cmake.py
@@ -34,10 +34,12 @@ from ament_tools.build_types.cmake_common import cmakecache_exists_at
 from ament_tools.build_types.cmake_common import get_visual_studio_version
 from ament_tools.build_types.cmake_common import has_make_target
 from ament_tools.build_types.cmake_common import MAKE_EXECUTABLE
+from ament_tools.build_types.cmake_common import NINJA_EXECUTABLE
 from ament_tools.build_types.cmake_common import makefile_exists_at
 from ament_tools.build_types.cmake_common import MSBUILD_EXECUTABLE
 from ament_tools.build_types.cmake_common import project_file_exists_at
 from ament_tools.build_types.cmake_common import solution_file_exists_at
+from ament_tools.build_types.cmake_common import ninjabuild_exists_at
 
 from ament_tools.build_types.common import expand_package_level_setup_files
 from ament_tools.build_types.common import get_cached_config
@@ -70,6 +72,10 @@ class CmakeBuildType(BuildType):
             help="Arbitrary arguments which are passed to all CTest invocations. "
                  "The option is only used by the 'test*' verbs. "
                  "Argument collection can be terminated with '--'.")
+        parser.add_argument(
+            '--ninja',
+            action='store_true',
+            help="Invoke 'cmake' with -G Ninja and call ninja instead of make.")
 
     def argument_preprocessor(self, args):
         # The CMake pass-through flag collects dashed options.
@@ -91,12 +97,18 @@ class CmakeBuildType(BuildType):
         ce.add('force_cmake_configure', force_cmake_configure)
         ce.add('cmake_args', options.cmake_args)
         ce.add('ctest_args', options.ctest_args)
+        ninja_build = False
+        if getattr(options, 'ninja', False):
+            ninja_build = True
+        ce.add('ninja_build', ninja_build)
         return ce
 
     def on_build(self, context):
         # Regardless of dry-run, try to determine if CMake should be invoked
         should_run_configure = False
         if context.force_cmake_configure:
+            should_run_configure = True
+        elif context.ninja_build and not ninjabuild_exists_at(context.build_space):
             should_run_configure = True
         elif not makefile_exists_at(context.build_space) or \
                 not cmakecache_exists_at(context.build_space):
@@ -123,6 +135,10 @@ class CmakeBuildType(BuildType):
         extra_cmake_args = []
         if should_run_configure:
             extra_cmake_args += context.cmake_args
+        if context.ninja_build:
+            extra_cmake_args += ['-G']
+            extra_cmake_args += ['Ninja']
+            extra_cmake_args += ["-DCMAKE_MAKE_PROGRAM=/usr/bin/ninja"]
         # Yield the cmake common on_build
         for step in self._common_cmake_on_build(
             should_run_configure, context, prefix, extra_cmake_args
@@ -159,9 +175,14 @@ class CmakeBuildType(BuildType):
             yield BuildAction(cmd)
         # Now execute the build step
         if not IS_WINDOWS:
-            if MAKE_EXECUTABLE is None:
-                raise VerbExecutionError("Could not find 'make' executable")
-            yield BuildAction(prefix + [MAKE_EXECUTABLE] + context.make_flags)
+            if context.ninja_build:
+                if NINJA_EXECUTABLE is None:
+                    raise VerbExecutionError("Could not find 'make' executable")
+                yield BuildAction(prefix + [NINJA_EXECUTABLE] + context.make_flags)
+            else:
+                if MAKE_EXECUTABLE is None:
+                    raise VerbExecutionError("Could not find 'make' executable")
+                yield BuildAction(prefix + [MAKE_EXECUTABLE] + context.make_flags)
         else:
             if MSBUILD_EXECUTABLE is None:
                 raise VerbExecutionError("Could not find 'msbuild' executable")
@@ -352,12 +373,17 @@ class CmakeBuildType(BuildType):
         prefix = self._get_command_prefix('install', context)
 
         if not IS_WINDOWS:
-            if has_make_target(context.build_space, 'install') or context.dry_run:
-                if MAKE_EXECUTABLE is None:
-                    raise VerbExecutionError("Could not find 'make' executable")
-                yield BuildAction(prefix + [MAKE_EXECUTABLE, 'install'])
+            if context.ninja_build:
+                if NINJA_EXECUTABLE is None:
+                    raise VerbExecutionError("Could not find 'ninja' executable")    
+                yield BuildAction(prefix + [NINJA_EXECUTABLE, 'install'])
             else:
-                self.warn('Could not run installation for package because it has no '
+                if has_make_target(context.build_space, 'install') or context.dry_run:
+                    if MAKE_EXECUTABLE is None:
+                        raise VerbExecutionError("Could not find 'make' executable")
+                    yield BuildAction(prefix + [MAKE_EXECUTABLE, 'install'])
+                else:
+                    self.warn('Could not run installation for package because it has no '
                           "'install' target")
         else:
             install_project_file = project_file_exists_at(

--- a/ament_tools/build_types/cmake.py
+++ b/ament_tools/build_types/cmake.py
@@ -371,7 +371,7 @@ class CmakeBuildType(BuildType):
         if not IS_WINDOWS:
             if context.use_ninja:
                 if NINJA_EXECUTABLE is None:
-                    raise VerbExecutionError("Could not find 'ninja' executable")    
+                    raise VerbExecutionError("Could not find 'ninja' executable")
                 yield BuildAction(prefix + [NINJA_EXECUTABLE, 'install'])
             else:
                 if has_make_target(context.build_space, 'install') or context.dry_run:
@@ -380,10 +380,9 @@ class CmakeBuildType(BuildType):
                     yield BuildAction(prefix + [MAKE_EXECUTABLE, 'install'])
                 else:
                     self.warn('Could not run installation for package because it has no '
-                          "'install' target")
+                              "'install' target")
         else:
-            install_project_file = project_file_exists_at(
-                context.build_space, 'INSTALL')
+            install_project_file = project_file_exists_at(context.build_space, 'INSTALL')
             if install_project_file is not None:
                 if MSBUILD_EXECUTABLE is None:
                     raise VerbExecutionError("Could not find 'msbuild' executable")

--- a/ament_tools/build_types/cmake.py
+++ b/ament_tools/build_types/cmake.py
@@ -34,12 +34,12 @@ from ament_tools.build_types.cmake_common import cmakecache_exists_at
 from ament_tools.build_types.cmake_common import get_visual_studio_version
 from ament_tools.build_types.cmake_common import has_make_target
 from ament_tools.build_types.cmake_common import MAKE_EXECUTABLE
-from ament_tools.build_types.cmake_common import NINJA_EXECUTABLE
 from ament_tools.build_types.cmake_common import makefile_exists_at
 from ament_tools.build_types.cmake_common import MSBUILD_EXECUTABLE
+from ament_tools.build_types.cmake_common import NINJA_EXECUTABLE
+from ament_tools.build_types.cmake_common import ninjabuild_exists_at
 from ament_tools.build_types.cmake_common import project_file_exists_at
 from ament_tools.build_types.cmake_common import solution_file_exists_at
-from ament_tools.build_types.cmake_common import ninjabuild_exists_at
 
 from ament_tools.build_types.common import expand_package_level_setup_files
 from ament_tools.build_types.common import get_cached_config

--- a/ament_tools/build_types/cmake.py
+++ b/ament_tools/build_types/cmake.py
@@ -75,7 +75,7 @@ class CmakeBuildType(BuildType):
         parser.add_argument(
             '--use-ninja',
             action='store_true',
-            help="Invoke 'cmake' with -G Ninja and call ninja instead of make.")
+            help="Invoke 'cmake' with '-G Ninja' and call ninja instead of make.")
 
     def argument_preprocessor(self, args):
         # The CMake pass-through flag collects dashed options.
@@ -133,8 +133,7 @@ class CmakeBuildType(BuildType):
         if should_run_configure:
             extra_cmake_args += context.cmake_args
         if context.use_ninja:
-            extra_cmake_args += ['-G']
-            extra_cmake_args += ['Ninja']
+            extra_cmake_args += ['-G', 'Ninja']
         # Yield the cmake common on_build
         for step in self._common_cmake_on_build(
             should_run_configure, context, prefix, extra_cmake_args

--- a/ament_tools/build_types/cmake_common.py
+++ b/ament_tools/build_types/cmake_common.py
@@ -44,9 +44,11 @@ def makefile_exists_at(path):
     makefile = os.path.join(path, 'Makefile')
     return os.path.isfile(makefile)
 
+
 def ninjabuild_exists_at(path):
-    ninjabuild = os.path.join(path,'build.ninja')
+    ninjabuild = os.path.join(path, 'build.ninja')
     return os.path.isfile(ninjabuild)
+
 
 def solution_file_exists_at(path, package_name):
     solution_file = os.path.join(path, package_name + '.sln')

--- a/ament_tools/build_types/cmake_common.py
+++ b/ament_tools/build_types/cmake_common.py
@@ -21,8 +21,8 @@ from osrf_pycommon.process_utils import which
 CMAKE_EXECUTABLE = which('cmake')
 CTEST_EXECUTABLE = which('ctest')
 MAKE_EXECUTABLE = which('make')
-NINJA_EXECUTABLE = which('ninja')
 MSBUILD_EXECUTABLE = which('msbuild')
+NINJA_EXECUTABLE = which('ninja')
 
 __target_re = re.compile(r'^([a-zA-Z0-9][a-zA-Z0-9_\.]*):')
 

--- a/ament_tools/build_types/cmake_common.py
+++ b/ament_tools/build_types/cmake_common.py
@@ -21,6 +21,7 @@ from osrf_pycommon.process_utils import which
 CMAKE_EXECUTABLE = which('cmake')
 CTEST_EXECUTABLE = which('ctest')
 MAKE_EXECUTABLE = which('make')
+NINJA_EXECUTABLE = which('ninja')
 MSBUILD_EXECUTABLE = which('msbuild')
 
 __target_re = re.compile(r'^([a-zA-Z0-9][a-zA-Z0-9_\.]*):')
@@ -43,6 +44,9 @@ def makefile_exists_at(path):
     makefile = os.path.join(path, 'Makefile')
     return os.path.isfile(makefile)
 
+def ninjabuild_exists_at(path):
+    ninjabuild = os.path.join(path,'build.ninja')
+    return os.path.isfile(ninjabuild)
 
 def solution_file_exists_at(path, package_name):
     solution_file = os.path.join(path, package_name + '.sln')


### PR DESCRIPTION
Hi,
many large projects are switching to (or at least are supporting) the ninja build system. The ninja build system has the advantage of a much smaller overhead than classical make files. For more information see: https://ninja-build.org/

This PR adds support in ament for building ROS2 with ninja. It does so by adding a new build option called --ninja. This options set a ninja_build flag which is then queried afterwards. If set to true cmake is passed the option -G Ninja and instead of make the ninja build tool is called. 

Please note that I'm not that familiar with python. So if anything of this PR looks like bad style or should be done in another way please tell me.

Edit: With ccache, gcc and gold linker I get a compile time for ROS2 of about 12 minutes compared to 14 minutes with make (also witch ccache, gcc and gold linker)