### PR TITLE
Fix AmentCmakeBuildType by tweaking its superclass.

### DIFF
--- a/ament_tools/build_types/cmake.py
+++ b/ament_tools/build_types/cmake.py
@@ -100,14 +100,14 @@ class CmakeBuildType(BuildType):
 
     def extend_context(self, options):
         ce = ContextExtender()
-        force_cmake_configure = options.force_cmake_configure
+        force_cmake_configure = getattr(options, 'force_cmake_configure', False)
         if getattr(options, 'force_configure', False):
             force_cmake_configure = True
         ce.add('force_cmake_configure', force_cmake_configure)
-        ce.add('cmake_args', options.cmake_args)
-        ce.add('ctest_args', options.ctest_args)
+        ce.add('cmake_args', getattr(options, 'cmake_args', []))
+        ce.add('ctest_args', getattr(options, 'ctest_args', []))
         ce.add('use_xcode', getattr(options, 'use_xcode', False))
-        ce.add('use_ninja', options.use_ninja)
+        ce.add('use_ninja', getattr(options, 'use_ninja', False))
         return ce
 
     def on_build(self, context):


### PR DESCRIPTION
AmentCmakeBuildType inherits to CmakeBuildType, but doesn't call its
superclass's methods creating options specific to CmakeBuildType.
Thus these options should be treated as optional.
Otherwise this exception gets triggered:
```
| --------------------------------------------------------------------------------
| Traceback (most recent call last):
|   File "/home/rojkov/work/ros/build/tmp-glibc/work/i586-oe-linux/rosidl-default-runtime/git-r0/recipe-sysroot-native/usr/bin/ament", line 11, in <module>
|     load_entry_point('ament-tools==0.0.0', 'console_scripts', 'ament')()
|   File "/home/rojkov/work/ros/build/tmp-glibc/work/i586-oe-linux/rosidl-default-runtime/git-r0/recipe-sysroot-native/usr/lib/python3.5/site-packages/ament_tools/commands/ament.py", line 89, in main
|     rc = args.main(args)
|   File "/home/rojkov/work/ros/build/tmp-glibc/work/i586-oe-linux/rosidl-default-runtime/git-r0/recipe-sysroot-native/usr/lib/python3.5/site-packages/ament_tools/verbs/build_pkg/cli.py", line 279, in main
|     context = get_context(opts)
|   File "/home/rojkov/work/ros/build/tmp-glibc/work/i586-oe-linux/rosidl-default-runtime/git-r0/recipe-sysroot-native/usr/lib/python3.5/site-packages/ament_tools/verbs/build_pkg/cli.py", line 285, in get_context
|     return create_context(opts)
|   File "/home/rojkov/work/ros/build/tmp-glibc/work/i586-oe-linux/rosidl-default-runtime/git-r0/recipe-sysroot-native/usr/lib/python3.5/site-packages/ament_tools/verbs/build_pkg/cli.py", line 401, in create_context
|     ce = build_type_impl.extend_context(opts)
|   File "/home/rojkov/work/ros/build/tmp-glibc/work/i586-oe-linux/rosidl-default-runtime/git-r0/recipe-sysroot-native/usr/lib/python3.5/site-packages/ament_tools/build_types/ament_cmake.py", line 59, in extend_context
|     ce = super(AmentCmakeBuildType, self).extend_context(options)
|   File "/home/rojkov/work/ros/build/tmp-glibc/work/i586-oe-linux/rosidl-default-runtime/git-r0/recipe-sysroot-native/usr/lib/python3.5/site-packages/ament_tools/build_types/cmake.py", line 103, in extend_context
|     force_cmake_configure = options.force_cmake_configure
| AttributeError: 'Namespace' object has no attribute 'force_cmake_configure'

```
