### PR TITLE
shlex.quote shell command parts

### DIFF
--- a/ament_tools/helper.py
+++ b/ament_tools/helper.py
@@ -17,6 +17,7 @@ import filecmp
 from multiprocessing import cpu_count
 import os
 import re
+import shlex
 import shutil
 import stat
 
@@ -285,3 +286,14 @@ def deploy_file(
         new_mode = mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
         if new_mode != mode:
             os.chmod(destination_path, new_mode)
+
+
+def quote_shell_command(cmd):
+    if os.name != 'nt':
+        return ' '.join([(shlex.quote(c) if c != '&&' else c) for c in cmd])
+    quoted = []
+    for c in cmd:
+        if ' ' in c:
+            c = '"%s"' % (c.replace('"', r'\"'))
+        quoted.append(c)
+    return ' '.join(quoted)

--- a/ament_tools/setup_arguments.py
+++ b/ament_tools/setup_arguments.py
@@ -24,6 +24,7 @@ import sys
 from threading import Lock
 
 from ament_tools.build_type import get_command_prefix
+from ament_tools.helper import quote_shell_command
 
 setup_lock = None
 
@@ -56,9 +57,10 @@ def get_setup_arguments_with_context(build_type, context):
         "print(repr(get_setup_arguments('%s')))" % setuppy]
 
     # invoke get_setup_arguments() in a separate interpreter
-    cmd = prefix + [sys.executable, '-c', '"%s"' % ';'.join(code_lines)]
+    cmd = prefix + [sys.executable, '-c', ';'.join(code_lines)]
+    cmd = quote_shell_command(cmd)
     result = subprocess.run(
-        ' '.join(cmd), stdout=subprocess.PIPE, shell=True, check=True)
+        cmd, stdout=subprocess.PIPE, shell=True, check=True)
     output = result.stdout.decode()
 
     return ast.literal_eval(output)


### PR DESCRIPTION
This patch makes sure that all parts of a shell command are quoted using `shlex.quote`. On Windows the function can't be used though since it quotes e.g. the executable with single quotes which doesn't work. Therefore on Windows a custom (very minimalistic) quoting is implemented.

It doesn't specifically target #160 but might fix it along the way. The quoting beyond #161 is still necessary in order to work for arguments which might also contain spaces.

Before (with whitespace in the various directories but not for the Python executable):
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3127)](http://ci.ros2.org/job/ci_linux/3127/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3178)](http://ci.ros2.org/job/ci_windows/3178/)

After (with whitespace in the various directories but not for the Python executable):
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3128)](http://ci.ros2.org/job/ci_linux/3128/) (unrelated test failures)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3185)](http://ci.ros2.org/job/ci_windows/3185/)

Just to make sure a set of "normal builds:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3129)](http://ci.ros2.org/job/ci_linux/3129/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=484)](http://ci.ros2.org/job/ci_linux-aarch64/484/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2493)](http://ci.ros2.org/job/ci_osx/2493/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3186)](http://ci.ros2.org/job/ci_windows/3186/)