### PR TITLE
ignore case for cmake 'project' and 'find_package'

### DIFF
--- a/ament_tools/package_types/cmake.py
+++ b/ament_tools/package_types/cmake.py
@@ -80,7 +80,7 @@ def extract_project_name(content):
     # optional quotes:                 vvvv               vv
     # project name:                        vvvvvvvvvvvvvvv
     # optional languages:                                       vvvvvvvv
-    match = re.search(r'project\s*\(\s*("?)([a-zA-Z0-9_]+)\1(\s+[^\)]*)?\)', content)
+    match = re.search(r'project\s*\(\s*("?)([a-zA-Z0-9_]+)\1(\s+[^\)]*)?\)', content, re.IGNORECASE)
     if not match:
         return None
     return match.group(2)
@@ -94,7 +94,7 @@ def extract_build_dependencies(content):
     # optional quotes:                         vvvv               vv
     # package name:                                vvvvvvvvvvvvvvv
     # optional arguments:                                               vvvvvvvv
-    matches = re.findall(r'find_package\s*\(\s*("?)([a-zA-Z0-9_]+)\1(\s+[^\)]*)?\)', content)
+    matches = re.findall(r'find_package\s*\(\s*("?)([a-zA-Z0-9_]+)\1(\s+[^\)]*)?\)', content, re.IGNORECASE)
     return [m[1] for m in matches]
 
 

--- a/ament_tools/package_types/cmake.py
+++ b/ament_tools/package_types/cmake.py
@@ -80,7 +80,8 @@ def extract_project_name(content):
     # optional quotes:                 vvvv               vv
     # project name:                        vvvvvvvvvvvvvvv
     # optional languages:                                       vvvvvvvv
-    match = re.search(r'project\s*\(\s*("?)([a-zA-Z0-9_]+)\1(\s+[^\)]*)?\)', content, re.IGNORECASE)
+    match = re.search(r'project\s*\(\s*("?)([a-zA-Z0-9_]+)\1(\s+[^\)]*)?\)', content,
+                      re.IGNORECASE)
     if not match:
         return None
     return match.group(2)
@@ -94,7 +95,8 @@ def extract_build_dependencies(content):
     # optional quotes:                         vvvv               vv
     # package name:                                vvvvvvvvvvvvvvv
     # optional arguments:                                               vvvvvvvv
-    matches = re.findall(r'find_package\s*\(\s*("?)([a-zA-Z0-9_]+)\1(\s+[^\)]*)?\)', content, re.IGNORECASE)
+    matches = re.findall(r'find_package\s*\(\s*("?)([a-zA-Z0-9_]+)\1(\s+[^\)]*)?\)', content,
+                         re.IGNORECASE)
     return [m[1] for m in matches]
 
 


### PR DESCRIPTION
Accept upper case `PROJECT` and `FIND_PACKAGE` in `CMakeLists.txt`.