### PR TITLE
Fix TOCTOU Bug in ament_tools helper.py

### DIFF
--- a/ament_tools/helper.py
+++ b/ament_tools/helper.py
@@ -269,7 +269,11 @@ def deploy_file(
         else:
             if not os.path.islink(destination_path) or \
                     not os.path.samefile(source_path, destination_path):
-                os.remove(destination_path)
+                # try-catch to guard against a TOCTOU error that can happen during parallel build.
+                try:
+                    os.remove(destination_path)
+                except OSError:
+                    pass
 
     if not os.path.exists(destination_path):
         if not context.symlink_install:
@@ -278,7 +282,11 @@ def deploy_file(
             # while the destination might not exist it can still be a symlink
             if os.path.islink(destination_path):
                 os.remove(destination_path)
-            os.symlink(source_path, destination_path)
+            # try-catch to guard against a TOCTOU error that can happen during parallel build
+            try:
+                os.symlink(source_path, destination_path)
+            except OSError:
+                pass
 
     # set executable bit if necessary
     if executable and not context.symlink_install:


### PR DESCRIPTION
## Description
- On my machine, the parallel build (`src/ament/ament_tools/scripts/ament.py build --symlink-install --parallel`) consistently breaks with an error similar to:

```
Traceback (most recent call last):
  File "/home/jp.samper/sketch_ws/ros2_ws/src/ament/ament_tools/ament_tools/verbs/build/cli.py", line 381, in process_in_parallel
    result = done_future.result()
  File "/usr/lib/python3.5/concurrent/futures/_base.py", line 398, in result
    return self.__get_result()
  File "/usr/lib/python3.5/concurrent/futures/_base.py", line 357, in __get_result
    raise self._exception
  File "/usr/lib/python3.5/concurrent/futures/thread.py", line 55, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/home/jp.samper/sketch_ws/ros2_ws/src/ament/ament_tools/ament_tools/verbs/build_pkg/cli.py", line 280, in main
    return run(opts, context)
  File "/home/jp.samper/sketch_ws/ros2_ws/src/ament/ament_tools/ament_tools/verbs/build_pkg/cli.py", line 339, in run
    deploy_prefix_level_setup_files(context)
  File "/home/jp.samper/sketch_ws/ros2_ws/src/ament/ament_tools/ament_tools/verbs/build_pkg/cli.py", line 307, in deploy_prefix_level_setup_files
    deploy_file(context, context.build_space, name[:-3])
  File "/home/jp.samper/sketch_ws/ros2_ws/src/ament/ament_tools/ament_tools/helper.py", line 282, in deploy_file
    os.symlink(source_path, destination_path)
FileExistsError: [Errno 17] File exists: '/home/jp.samper/sketch_ws/ros2_ws/build/ament_cmake_pyflakes/local_setup.sh' -> '/home/jp.samper/sketch_ws/ros2_ws/install/local_setup.sh'
```
- Basically, the OS tries to create a symlink, but it finds that the symlink already exists, even though just a few lines above, it had checked that it didn't exist.
- The same thing happens in line 272, when the script tries to remove a file that doesn't exist, even though few lines above it had checked that it did exist.

## How to test
- As with all race conditions, it may be hard to reproduce the bug on other machines, but I can consistently reproduce it in mine, and this fix consistently prevents it.

## Fix
- I think it's safe to pass on the os.remove error -- who cares if you can't delete a file that doesn't exist anyway
- I'm not sure what the best approach is for the symlink: Do we pass on the exception? Or do we delete the existing symlink and try again?
