### PR TITLE
check CMAKE_COMMAND environment variable and look for cmake3 executab…

### DIFF
--- a/ament_tools/build_types/cmake.py
+++ b/ament_tools/build_types/cmake.py
@@ -24,8 +24,10 @@ from ament_tools.build_type import BuildAction
 from ament_tools.build_type import BuildType
 
 from ament_tools.build_types.cmake_common import CMAKE_EXECUTABLE
+from ament_tools.build_types.cmake_common import CMAKE_EXECUTABLE_ENV
 from ament_tools.build_types.cmake_common import cmakecache_exists_at
 from ament_tools.build_types.cmake_common import CTEST_EXECUTABLE
+from ament_tools.build_types.cmake_common import CTEST_EXECUTABLE_ENV
 from ament_tools.build_types.cmake_common import get_visual_studio_version
 from ament_tools.build_types.cmake_common import has_make_target
 from ament_tools.build_types.cmake_common import MAKE_EXECUTABLE
@@ -196,7 +198,8 @@ class CmakeBuildType(BuildType):
                 else:
                     cmake_args += ['-G', 'Unix Makefiles']
             if CMAKE_EXECUTABLE is None:
-                raise VerbExecutionError("Could not find 'cmake' executable")
+                raise VerbExecutionError("Could not find 'cmake' executable, try setting " +
+                                         CMAKE_EXECUTABLE_ENV)
             yield BuildAction(prefix + [CMAKE_EXECUTABLE] + cmake_args)
         elif IS_LINUX:  # Check for reconfigure if available.
             if MAKE_EXECUTABLE is None:
@@ -299,7 +302,8 @@ class CmakeBuildType(BuildType):
                 yield build_action
         elif IS_WINDOWS:
             if CTEST_EXECUTABLE is None:
-                raise VerbExecutionError("Could not find 'ctest' executable")
+                raise VerbExecutionError("Could not find 'ctest' executable, try setting " +
+                                         CTEST_EXECUTABLE_ENV)
             # invoke CTest directly in order to pass arguments
             # it needs a specific configuration and currently there are no conf. specific tests
             cmd = prefix + [

--- a/ament_tools/build_types/cmake.py
+++ b/ament_tools/build_types/cmake.py
@@ -198,8 +198,9 @@ class CmakeBuildType(BuildType):
                 else:
                     cmake_args += ['-G', 'Unix Makefiles']
             if CMAKE_EXECUTABLE is None:
-                raise VerbExecutionError("Could not find 'cmake' executable, try setting " +
-                                         CMAKE_EXECUTABLE_ENV)
+                raise VerbExecutionError(
+                    "Could not find 'cmake' executable, try setting the "
+                    'environment variable' + CMAKE_EXECUTABLE_ENV)
             yield BuildAction(prefix + [CMAKE_EXECUTABLE] + cmake_args)
         elif IS_LINUX:  # Check for reconfigure if available.
             if MAKE_EXECUTABLE is None:
@@ -302,8 +303,9 @@ class CmakeBuildType(BuildType):
                 yield build_action
         elif IS_WINDOWS:
             if CTEST_EXECUTABLE is None:
-                raise VerbExecutionError("Could not find 'ctest' executable, try setting " +
-                                         CTEST_EXECUTABLE_ENV)
+                raise VerbExecutionError(
+                    "Could not find 'ctest' executable, try setting the "
+                    'environment variable ' + CTEST_EXECUTABLE_ENV)
             # invoke CTest directly in order to pass arguments
             # it needs a specific configuration and currently there are no conf. specific tests
             cmd = prefix + [

--- a/ament_tools/build_types/cmake_common.py
+++ b/ament_tools/build_types/cmake_common.py
@@ -19,10 +19,9 @@ import subprocess
 from osrf_pycommon.process_utils import which
 
 
+# look for CMAKE_COMMAND env var and cmake3 before cmake
+# for systems that have both 2.x and 3.x installed
 def which_cmake_executable():
-    '''look for CMAKE_COMMAND env var and cmake3 before cmake
-    for systems that have both 2.x and 3.x installed
-    '''
     executable = which(os.getenv("CMAKE_COMMAND", 'cmake3'))
     if executable is None:
         executable = which('cmake')

--- a/ament_tools/build_types/cmake_common.py
+++ b/ament_tools/build_types/cmake_common.py
@@ -18,8 +18,24 @@ import subprocess
 
 from osrf_pycommon.process_utils import which
 
-CMAKE_EXECUTABLE = which('cmake')
-CTEST_EXECUTABLE = which('ctest')
+def which_cmake_executable():
+    '''look for CMAKE_COMMAND env var and cmake3 before cmake
+    for systems that have both 2.x and 3.x installed
+    '''
+    executable = which(os.getenv("CMAKE_COMMAND", 'cmake3'))
+    if executable is None:
+        executable = which('cmake')
+    return executable
+
+def which_ctest_executable():
+    executable = which(os.getenv("CTEST_COMMAND", 'ctest3'))
+    if executable is None:
+        executable = which('ctest')
+    return executable
+
+
+CMAKE_EXECUTABLE = which_cmake_executable()
+CTEST_EXECUTABLE = which_ctest_executable()
 MAKE_EXECUTABLE = which('make')
 MSBUILD_EXECUTABLE = which('msbuild')
 NINJA_EXECUTABLE = which('ninja')
@@ -68,3 +84,4 @@ def project_file_exists_at(path, target):
 def get_visual_studio_version():
     vsv = os.environ.get('VisualStudioVersion', None)
     return vsv
+

--- a/ament_tools/build_types/cmake_common.py
+++ b/ament_tools/build_types/cmake_common.py
@@ -18,6 +18,7 @@ import subprocess
 
 from osrf_pycommon.process_utils import which
 
+
 def which_cmake_executable():
     '''look for CMAKE_COMMAND env var and cmake3 before cmake
     for systems that have both 2.x and 3.x installed
@@ -26,6 +27,7 @@ def which_cmake_executable():
     if executable is None:
         executable = which('cmake')
     return executable
+
 
 def which_ctest_executable():
     executable = which(os.getenv("CTEST_COMMAND", 'ctest3'))
@@ -84,4 +86,3 @@ def project_file_exists_at(path, target):
 def get_visual_studio_version():
     vsv = os.environ.get('VisualStudioVersion', None)
     return vsv
-

--- a/ament_tools/build_types/cmake_common.py
+++ b/ament_tools/build_types/cmake_common.py
@@ -18,25 +18,25 @@ import subprocess
 
 from osrf_pycommon.process_utils import which
 
-
-# look for CMAKE_COMMAND env var and cmake3 before cmake
-# for systems that have both 2.x and 3.x installed
-def which_cmake_executable():
-    executable = which(os.getenv("CMAKE_COMMAND", 'cmake3'))
-    if executable is None:
-        executable = which('cmake')
-    return executable
+CMAKE_EXECUTABLE_ENV = 'CMAKE_COMMAND'
+CTEST_EXECUTABLE_ENV = 'CTEST_COMMAND'
 
 
-def which_ctest_executable():
-    executable = which(os.getenv("CTEST_COMMAND", 'ctest3'))
-    if executable is None:
-        executable = which('ctest')
-    return executable
+def which_executable(env_var, executable_names):
+    env_value = os.getenv(env_var)
+    if env_value:
+        executable = which(env_value)
+        if executable:
+            return executable
+    for executable_name in executable_names:
+        executable = which(executable_name)
+        if executable:
+            return executable
+    return None
 
 
-CMAKE_EXECUTABLE = which_cmake_executable()
-CTEST_EXECUTABLE = which_ctest_executable()
+CMAKE_EXECUTABLE = which_executable(CMAKE_EXECUTABLE_ENV, ['cmake3', 'cmake'])
+CTEST_EXECUTABLE = which_executable(CTEST_EXECUTABLE_ENV, ['ctest3', 'ctest'])
 MAKE_EXECUTABLE = which('make')
 MSBUILD_EXECUTABLE = which('msbuild')
 NINJA_EXECUTABLE = which('ninja')


### PR DESCRIPTION
Attempting to build ament on CentOS 7 with CMake 3.x fails because ament is hard coded to look for an executable named `cmake`. The RPM for CMake 3.x renames the executable `cmake3` to avoid conflict with CMake 2.x. This patch modifies ament_tools to check the CMAKE_COMMAND environment variable for user override and for a `cmake3` executable before looking for `cmake`