### PR TITLE
Travis CI integration on Mac + Code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,20 @@
 language: python
-python:
-#  - "2.7"
-  - "3.5"
 sudo: false
+matrix:
+  include:
+    - os: linux
+      python: 3.5
+    - os: osx
+      language: generic
+      env: PYTHON_INSTALLER=brew
+    - os: osx
+      language: generic
+      env: PYTHON_INSTALLER=pyenv TRAVIS_PYTHON_VERSION=3.6.4
+
 install:
+  - source .travis/install.sh
   - pip install nose
-  - pip install flake8 pydocstyle
+  - pip install flake8 pydocstyle codecov
 # For now install ament_package from git
   - git clone https://github.com/ament/ament_package.git
   - cd ament_package
@@ -28,6 +37,8 @@ install:
   - python setup.py install
   - cd ../..
 script:
-  - python setup.py nosetests -s
+  - python setup.py nosetests -s --with-coverage --cover-package=ament_tools
+after_script:
+  - codecov
 notifications:
   email: false

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -x
+
+do_install()
+{
+    set -e
+
+    if [[ $TRAVIS_OS_NAME == 'osx' && $PYTHON_INSTALLER == 'pyenv' ]]; then
+        brew install pyenv-virtualenv
+        pyenv versions
+        eval "$(pyenv init -)"
+        pyenv install $TRAVIS_PYTHON_VERSION
+        PYTHON_ENV_NAME=virtual-env-$TRAVIS_PYTHON_VERSION
+        pyenv virtualenv $TRAVIS_PYTHON_VERSION $PYTHON_ENV_NAME
+        pyenv activate $PYTHON_ENV_NAME
+
+    elif [[ $TRAVIS_OS_NAME == 'osx' && $PYTHON_INSTALLER == 'brew' ]]; then
+        brew list
+        brew upgrade python3
+        # nose 1.3.7 creates /usr/local/man dir if it does not exist.
+        # The operation fails because current user does not own /usr/local.  Create the dir manually instead.
+        # More at https://github.com/nose-devs/nose/issues/1017
+        sudo mkdir /usr/local/man
+        sudo chown -R $(whoami) $(brew --prefix)/*
+
+        export PATH=$(pwd)/.travis/shim:$PATH
+    fi
+
+    set +e
+}
+
+do_install

--- a/.travis/shim/pip
+++ b/.travis/shim/pip
@@ -1,0 +1,3 @@
+#!/bin/sh
+pip3 $@
+exit $?

--- a/.travis/shim/python
+++ b/.travis/shim/python
@@ -1,0 +1,3 @@
+#!/bin/sh
+python3 $@
+exit $?

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
     version='0.4.0',
     packages=find_packages(exclude=['test', 'test.*']),
     install_requires=['ament-package', 'osrf_pycommon'],
+    zip_safe=False,
     data_files=[
         ('share/ament_tools/environment',
             [


### PR DESCRIPTION
Run the process on OCX with 2 versions of python - python3 from brew, and python 3.6.4 from pyenv.

Get code coverage numbers and upload them to CodeCov service.