### PR TITLE
Fix python unittest runtime error in ament_tools

### DIFF
--- a/ament_tools/build_types/ament_python.py
+++ b/ament_tools/build_types/ament_python.py
@@ -90,7 +90,6 @@ class AmentPythonBuildType(BuildType):
             context.package_manifest.name, 'pytest.xunit.xml')
         os.makedirs(os.path.dirname(xunit_file), exist_ok=True)
         args = [
-            '-o cache_dir=' + os.path.join(context.build_space, '.cache'),
             '--junit-xml=' + xunit_file,
             '--junit-prefix=' + context.package_manifest.name,
         ]


### PR DESCRIPTION
Fix python unittest runtime error due to no support to option `-o` in `python3-pytest`

Signed-off-by: Ethan Gao <ethan.gao@linux.intel.com>